### PR TITLE
Shared Build Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,23 @@ jobs:
       run: |
         ./util/download-dxc.sh
 
-    - name: Build
+    - name: Build Static
       shell: bash
       run: |
-        mkdir bld
-        cd bld
+        mkdir bld-static
+        cd bld-static
         cmake --version
         cmake .. -DVulkan_BIN_DIR=$HOME/dxc-artifacts/bin
-        cmake .. -DVulkan_BIN_DIR=$HOME/dxc-artifacts/bin
+        make VERBOSE=1 -j4
+
+    - name: Build Shared
+      shell: bash
+      run: |
+        mkdir bld-shared
+        cd bld-shared
+        cmake --version
+        cmake .. -DVulkan_BIN_DIR=$HOME/dxc-artifacts/bin \
+                 -DGPRT_BUILD_SHARED=ON
         make VERBOSE=1 -j4
 
     # Just checking build until a CPU backend is ready

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,14 @@ if (NOT GPRT_IS_SUBPROJECT)
 endif()
 
 # ------------------------------------------------------------------
+# Configuration Options
+# ------------------------------------------------------------------
+option(GPRT_BUILD_SHARED "Build GPRT as a shared library? (otherwise static)" OFF)
+set(BUILD_SHARED_LIBS ${GPRT_BUILD_SHARED}) # use 'GPRT_' naming convention
+
+option(GPRT_BUILD_SAMPLES "Build the Samples?" ON)
+
+# ------------------------------------------------------------------
 # first, include some dependencies
 # ------------------------------------------------------------------
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/gprt/cmake/")
@@ -53,24 +61,22 @@ endif()
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if (GPRT_BUILD_SHARED)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 option(OWL_BUILD_SAMPLES "Build the Samples?" ON)
 
+add_subdirectory(3rdParty)
+
+
 # ------------------------------------------------------------------
 # gprt library itself
 # ------------------------------------------------------------------
-option(GPRT_BUILD_SHARED "Build GPRT as a shared library? (otherwise static)" OFF)
-set(BUILD_SHARED_LIBS ${GPRT_BUILD_SHARED}) # use 'GPRT_' naming convention
 add_subdirectory(gprt)
-
-option(GPRT_BUILD_SAMPLES "Build the Samples?" ON)
-# add_compile_definitions(GPRT_BUILDING_ALL_SAMPLES)
-# option(GPRT_BUILD_ADVANCED_TESTS "Build the *advanced* test-cases?" OFF)
-
-add_subdirectory(3rdParty)
 
 # ------------------------------------------------------------------
 # tutorial/samples

--- a/gprt/CMakeLists.txt
+++ b/gprt/CMakeLists.txt
@@ -21,7 +21,9 @@
 # SOFTWARE.
 
 add_library(gprt)
-
+if (GPRT_BUILD_SHARED)
+  set_property(TARGET gprt PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
 include(cmake/hlsl_embed_spirv.cmake)
 
 embed_spirv(
@@ -58,9 +60,9 @@ set_target_properties(gprt
 #     )
 # ENDIF(WIN32)
 
-target_link_libraries(gprt 
-    PUBLIC 
-    ${Vulkan_LIBRARY} 
+target_link_libraries(gprt
+    PUBLIC
+    ${Vulkan_LIBRARY}
     gprtDeviceCode
 )
 


### PR DESCRIPTION
This makes some changes to the `CMakeLists.txt` file to support shared builds of GPRT. Just needed to re-order some calls to do so. I also moved any options we have to the top of the file (hope that's cool @natevm) and got rid of the unused `OWL_BUILD_SAMPLES` option.

Closes #2