### PR TITLE
Absolute include dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,15 @@ set(BUILD_SHARED_LIBS ${GPRT_BUILD_SHARED}) # use 'GPRT_' naming convention
 option(GPRT_BUILD_SAMPLES "Build the Samples?" ON)
 
 # ------------------------------------------------------------------
+# External configuration variables
+# ------------------------------------------------------------------
+
+# provide these varaibles at both a local and parent scope
+set(GPRT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gprt PARENT_SCOPE)
+set(GPRT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gprt)
+
+
+# ------------------------------------------------------------------
 # first, include some dependencies
 # ------------------------------------------------------------------
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/gprt/cmake/")
@@ -88,6 +97,7 @@ endif()
 if (GPRT_IS_SUBPROJECT)
   return()
 endif()
+
 
 # include(CTest)
 # if (BUILD_TESTING)

--- a/gprt/cmake/hlsl_embed_spirv.cmake
+++ b/gprt/cmake/hlsl_embed_spirv.cmake
@@ -74,7 +74,7 @@ function(embed_spirv)
       -fspv-target-env=vulkan1.1spirv1.4
       -HV 2021
       -T lib_6_3
-      -I ${PROJECT_SOURCE_DIR}/gprt
+      -I ${GPRT_INCLUDE_DIR}
       -D GPRT_DEVICE
       -D ${ENTRY_POINT_TYPE}
       -fspv-extension=SPV_KHR_ray_tracing
@@ -85,7 +85,7 @@ function(embed_spirv)
       -fcgl
       ${EMBED_SPIRV_SOURCES}
       -Fo ${CMAKE_CURRENT_BINARY_DIR}/${EMBED_SPIRV_OUTPUT_TARGET}_${ENTRY_POINT_TYPE}.spv
-      DEPENDS ${EMBED_SPIRV_SOURCES} ${PROJECT_SOURCE_DIR}/gprt/gprt_device.hlsli ${PROJECT_SOURCE_DIR}/gprt/gprt.h
+      DEPENDS ${EMBED_SPIRV_SOURCES} ${GPRT_INCLUDE_DIR}/gprt_device.hlsli ${GPRT_INCLUDE_DIR}/gprt.h
       COMMENT "compile SPIRV ${CMAKE_CURRENT_BINARY_DIR}/${EMBED_SPIRV_OUTPUT_TARGET}_${ENTRY_POINT_TYPE}.spv from ${EMBED_SPIRV_SOURCES}"
     )
 


### PR DESCRIPTION
I ran into a missing make target for `../gprt/gprt.h` when using the `embed_spirv` function. This came down to the use of a relative path in that function based on the CMake from which the `embed_spirv` function was being called. 

I've added a general include directory variable for gprt in it's main CMake file. I provided both a local and parent scope variable in case GPRT is being used as a subproject. I considered a cached variable, but I find those more clunky to handle.