### PR TITLE
Only set parent scope if GPRT is subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,9 @@ option(GPRT_BUILD_SAMPLES "Build the Samples?" ON)
 # ------------------------------------------------------------------
 
 # provide these varaibles at both a local and parent scope
-set(GPRT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gprt PARENT_SCOPE)
+if (GPRT_IS_SUBPROJECT)
+  set(GPRT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gprt PARENT_SCOPE)
+endif()
 set(GPRT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gprt)
 
 


### PR DESCRIPTION
Follow-on to #4 to fix the warning

```
CMake Warning (dev) at CMakeLists.txt:59 (set):
  Cannot set "GPRT_INCLUDE_DIR": current scope has no parent.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

that is seen if GPRT is built as a standalone project.
