### PR TITLE
Refactors buffer API slightly; Introduces a shared buffer type

### DIFF
--- a/gprt/gprt_host.h
+++ b/gprt/gprt_host.h
@@ -685,16 +685,24 @@ gprtGeomTypeSetIntersectionProg(GPRTGeomType type,
                              GPRTModule module,
                              const char *progName);
 
-/*! creates a buffer that uses host pinned memory; that memory is
-pinned on the host and accessible to all devices */
+/*! Creates a buffer that uses memory located on the host; that memory is 
+accessible to all devices, but is slower to access on device.  */
 GPRT_API GPRTBuffer
-gprtHostPinnedBufferCreate(GPRTContext context, GPRTDataType type, size_t count, 
+gprtHostBufferCreate(GPRTContext context, GPRTDataType type, size_t count, 
   const void* init GPRT_IF_CPP(= nullptr));
 
-/*! creates a device buffer where every device has its own local copy
-  of the given buffer */
+/*! Creates a buffer that uses memory located on the device; that memory is 
+accessible only to the device, and requires mapping and unmapping to access 
+on the host. */
 GPRT_API GPRTBuffer
 gprtDeviceBufferCreate(GPRTContext context, GPRTDataType type, size_t count, 
+  const void* init GPRT_IF_CPP(= nullptr));
+
+/*! Creates a buffer that uses memory located on the device; that memory is 
+accessible to all devices, but is slower to access on the host, and is typically
+limited in size depending on resizable BAR availability. */
+GPRT_API GPRTBuffer
+gprtSharedBufferCreate(GPRTContext context, GPRTDataType type, size_t count, 
   const void* init GPRT_IF_CPP(= nullptr));
 
 /*! Destroys all underlying Vulkan resources for the given buffer and frees any

--- a/samples/cmd00-rayGenOnly/hostCode.cpp
+++ b/samples/cmd00-rayGenOnly/hostCode.cpp
@@ -93,7 +93,7 @@ int main(int ac, char **av)
   LOG("allocating frame buffer");
   // Create a frame buffer as page-locked, aka "pinned" memory.
   // GPU writes to CPU memory directly (slow) but no transfers needed
-  GPRTBuffer frameBuffer = gprtHostPinnedBufferCreate(gprt,
+  GPRTBuffer frameBuffer = gprtHostBufferCreate(gprt,
                                           /*type:*/GPRT_INT,
                                           /*size:*/fbSize.x*fbSize.y);
 

--- a/samples/cmd01-simpleTriangles/hostCode.cpp
+++ b/samples/cmd01-simpleTriangles/hostCode.cpp
@@ -120,13 +120,13 @@ int main(int ac, char **av)
   // triangle mesh
   // ------------------------------------------------------------------
   GPRTBuffer vertexBuffer
-    = gprtHostPinnedBufferCreate(context,GPRT_FLOAT3,NUM_VERTICES,vertices);
+    = gprtHostBufferCreate(context,GPRT_FLOAT3,NUM_VERTICES,vertices);
   GPRTBuffer indexBuffer
     = gprtDeviceBufferCreate(context,GPRT_INT3,NUM_INDICES,indices);
   GPRTBuffer transformBuffer
     = gprtDeviceBufferCreate(context,GPRT_TRANSFORM,1,transform);
   GPRTBuffer frameBuffer
-    = gprtHostPinnedBufferCreate(context,GPRT_INT,fbSize.x*fbSize.y);
+    = gprtHostBufferCreate(context,GPRT_INT,fbSize.x*fbSize.y);
 
   GPRTGeom trianglesGeom
     = gprtGeomCreate(context,trianglesGeomType);

--- a/samples/cmd02-simpleAABBs/hostCode.cpp
+++ b/samples/cmd02-simpleAABBs/hostCode.cpp
@@ -119,7 +119,7 @@ int main(int ac, char **av)
   GPRTBuffer transformBuffer
     = gprtDeviceBufferCreate(context,GPRT_TRANSFORM,1,transform);
   GPRTBuffer frameBuffer
-    = gprtHostPinnedBufferCreate(context,GPRT_INT,fbSize.x*fbSize.y);
+    = gprtHostBufferCreate(context,GPRT_INT,fbSize.x*fbSize.y);
 
   GPRTGeom aabbGeom
     = gprtGeomCreate(context,aabbGeomType);

--- a/samples/cmd03-computeOnly/hostCode.cpp
+++ b/samples/cmd03-computeOnly/hostCode.cpp
@@ -93,7 +93,7 @@ int main(int ac, char **av)
   LOG("allocating frame buffer");
   // Create a frame buffer as page-locked, aka "pinned" memory.
   // GPU writes to CPU memory directly (slow) but no transfers needed
-  GPRTBuffer frameBuffer = gprtHostPinnedBufferCreate(gprt,
+  GPRTBuffer frameBuffer = gprtHostBufferCreate(gprt,
                                           /*type:*/GPRT_INT,
                                           /*size:*/fbSize.x*fbSize.y);
 

--- a/samples/int00-rayGenOnly/hostCode.cpp
+++ b/samples/int00-rayGenOnly/hostCode.cpp
@@ -90,7 +90,7 @@ int main(int ac, char **av)
   LOG("allocating frame buffer");
   // Create a frame buffer as page-locked, aka "pinned" memory.
   // GPU writes to CPU memory directly (slow) but no transfers needed
-  GPRTBuffer frameBuffer = gprtHostPinnedBufferCreate(gprt,
+  GPRTBuffer frameBuffer = gprtHostBufferCreate(gprt,
                                           /*type:*/GPRT_INT,
                                           /*size:*/fbSize.x*fbSize.y);
 

--- a/samples/int01-simpleTriangles/hostCode.cpp
+++ b/samples/int01-simpleTriangles/hostCode.cpp
@@ -123,13 +123,13 @@ int main(int ac, char **av)
   // triangle mesh
   // ------------------------------------------------------------------
   GPRTBuffer vertexBuffer
-    = gprtHostPinnedBufferCreate(context,GPRT_FLOAT3,NUM_VERTICES,vertices);
+    = gprtHostBufferCreate(context,GPRT_FLOAT3,NUM_VERTICES,vertices);
   GPRTBuffer indexBuffer
     = gprtDeviceBufferCreate(context,GPRT_INT3,NUM_INDICES,indices);
   GPRTBuffer transformBuffer
     = gprtDeviceBufferCreate(context,GPRT_TRANSFORM,1,transform);
   GPRTBuffer frameBuffer
-    = gprtHostPinnedBufferCreate(context,GPRT_INT,fbSize.x*fbSize.y);
+    = gprtHostBufferCreate(context,GPRT_INT,fbSize.x*fbSize.y);
 
   GPRTGeom trianglesGeom
     = gprtGeomCreate(context,trianglesGeomType);

--- a/samples/int02-simpleAABBs/hostCode.cpp
+++ b/samples/int02-simpleAABBs/hostCode.cpp
@@ -122,7 +122,7 @@ int main(int ac, char **av)
   GPRTBuffer transformBuffer
     = gprtDeviceBufferCreate(context,GPRT_TRANSFORM,1,transform);
   GPRTBuffer frameBuffer
-    = gprtHostPinnedBufferCreate(context,GPRT_INT,fbSize.x*fbSize.y);
+    = gprtHostBufferCreate(context,GPRT_INT,fbSize.x*fbSize.y);
 
   GPRTGeom aabbGeom
     = gprtGeomCreate(context,aabbGeomType);

--- a/samples/int04-computeAABBs/hostCode.cpp
+++ b/samples/int04-computeAABBs/hostCode.cpp
@@ -182,7 +182,7 @@ int main(int ac, char **av)
 
   // ----------- set raygen variables  ----------------------------
   GPRTBuffer frameBuffer
-    = gprtHostPinnedBufferCreate(context,GPRT_INT,fbSize.x*fbSize.y);
+    = gprtHostBufferCreate(context,GPRT_INT,fbSize.x*fbSize.y);
   gprtRayGenSetBuffer(rayGen,"fbPtr", frameBuffer);
   gprtRayGenSet2iv(rayGen,"fbSize", (int32_t*)&fbSize);
   gprtRayGenSetAccel(rayGen,"world", world);

--- a/samples/int05-computePrimitive/hostCode.cpp
+++ b/samples/int05-computePrimitive/hostCode.cpp
@@ -185,7 +185,7 @@ int main(int ac, char **av)
 
   // ----------- set raygen variables  ----------------------------
   GPRTBuffer frameBuffer
-    = gprtHostPinnedBufferCreate(context,GPRT_INT,fbSize.x*fbSize.y);
+    = gprtHostBufferCreate(context,GPRT_INT,fbSize.x*fbSize.y);
   gprtRayGenSetBuffer(rayGen,"fbPtr", frameBuffer);
   gprtRayGenSet2iv(rayGen,"fbSize", (int32_t*)&fbSize);
   gprtRayGenSetAccel(rayGen,"world", world);

--- a/samples/int07-doublePrecision/hostCode.cpp
+++ b/samples/int07-doublePrecision/hostCode.cpp
@@ -186,7 +186,7 @@ int main(int ac, char **av)
 
   // ----------- set raygen variables  ----------------------------
   GPRTBuffer frameBuffer
-    = gprtHostPinnedBufferCreate(context,GPRT_INT,fbSize.x*fbSize.y);
+    = gprtHostBufferCreate(context,GPRT_INT,fbSize.x*fbSize.y);
   
   // need this to communicate double precision rays to intersection program
   // ray origin xyz + tmin, then ray direction xyz + tmax


### PR DESCRIPTION
This PR renames the "gprtHostPinnedBufferCreate" function to just "gprtPinnedBufferCreate".
- We're doing this because we do not plan on exposing a non-pinned host buffer, and this reduces the verbosity of this call

This PR also introduces a new function, "gprtSharedBufferCreate"
- We use this function to expose "BAR" memory on the device, which is device memory who's visibility is shared with the host.

This solves issue #1 