### PR TITLE
Add support for multiple instance acceleration structures

### DIFF
--- a/gprt/gprt_device_code.hlsl
+++ b/gprt/gprt_device_code.hlsl
@@ -31,13 +31,15 @@ void __compute__gprtFillInstanceData( uint3 DTid : SV_DispatchThreadID )
   uint64_t instanceBufferPtr = pc.r[0];
   uint64_t transformBufferPtr = pc.r[1];
   uint64_t accelReferencesPtr = pc.r[2];
+  uint64_t instanceShaderBindingTableRecordOffset = pc.r[3];
 
   VkAccelerationStructureInstanceKHR instance;
   // float3x4 transform = vk::RawBufferLoad<float3x4>(
   //     transformBufferPtr + sizeof(float3x4) * DTid.x);;
   
   instance.instanceCustomIndex24Mask8 = 0 | 0xFF << 24;
-  instance.instanceShaderBindingTableRecordOffset24Flags8 = 0 | 0x00 << 24;
+  instance.instanceShaderBindingTableRecordOffset24Flags8 = 
+    int(instanceShaderBindingTableRecordOffset) | 0x00 << 24;
 
   // this is gross, but AMD has a bug where loading 3x4 transforms causes a random crash when creating shader modules.
   instance.transforma = 

--- a/gprt/gprt_host.h
+++ b/gprt/gprt_host.h
@@ -472,9 +472,12 @@ GPRT_API void gprtAABBsSetPositions(GPRTGeom aabbs,
                                     size_t stride,
                                     size_t offset);
 
-GPRT_API void gprtBuildPrograms(GPRTContext context);
+/* Builds the ray tracing pipeline over the raytracing programs. 
+  This must be called after any acceleration structures are created.
+*/
+GPRT_API void gprtBuildPipeline(GPRTContext context);
 
-GPRT_API void gprtBuildSBT(GPRTContext context,
+GPRT_API void gprtBuildShaderBindingTable(GPRTContext context,
                          GPRTBuildSBTFlags flags GPRT_IF_CPP(=GPRT_SBT_ALL));
 
 /*! creates a new device context with the gives list of devices.

--- a/samples/cmd00-rayGenOnly/hostCode.cpp
+++ b/samples/cmd00-rayGenOnly/hostCode.cpp
@@ -85,7 +85,7 @@ int main(int ac, char **av)
                       sizeof(RayGenData),rayGenVars,-1); // -1 maybe should be the default here...
 
   // (re-)builds all vulkan programs, with current pipeline settings
-  gprtBuildPrograms(gprt);
+  gprtBuildPipeline(gprt);
 
   // ------------------------------------------------------------------
   // alloc buffers
@@ -105,7 +105,7 @@ int main(int ac, char **av)
   gprtRayGenSetBuffer(rayGen,"fbPtr",frameBuffer);
   gprtRayGenSet2i(rayGen,"fbSize",fbSize.x,fbSize.y);
   // Build a shader binding table entry for the ray generation record.
-  gprtBuildSBT(gprt);
+  gprtBuildShaderBindingTable(gprt);
 
   // ##################################################################
   // now that everything is ready: launch it ....

--- a/samples/cmd01-simpleTriangles/hostCode.cpp
+++ b/samples/cmd01-simpleTriangles/hostCode.cpp
@@ -221,8 +221,8 @@ int main(int ac, char **av)
   // ##################################################################
   // build *SBT* required to trace the groups
   // ##################################################################
-  gprtBuildPrograms(context);
-  gprtBuildSBT(context);
+  gprtBuildPipeline(context);
+  gprtBuildShaderBindingTable(context);
 
   // ##################################################################
   // now that everything is ready: launch it ....

--- a/samples/cmd02-simpleAABBs/hostCode.cpp
+++ b/samples/cmd02-simpleAABBs/hostCode.cpp
@@ -211,8 +211,8 @@ int main(int ac, char **av)
   // ##################################################################
   // build *SBT* required to trace the groups
   // ##################################################################
-  gprtBuildPrograms(context);
-  gprtBuildSBT(context);
+  gprtBuildPipeline(context);
+  gprtBuildShaderBindingTable(context);
 
   // ##################################################################
   // now that everything is ready: launch it ....

--- a/samples/cmd03-computeOnly/hostCode.cpp
+++ b/samples/cmd03-computeOnly/hostCode.cpp
@@ -85,7 +85,7 @@ int main(int ac, char **av)
                       sizeof(ComputeData),computeVars,-1);
 
   // (re-)builds all vulkan programs, with current pipeline settings
-  gprtBuildPrograms(gprt);
+  gprtBuildPipeline(gprt);
 
   // ------------------------------------------------------------------
   // alloc buffers
@@ -105,7 +105,7 @@ int main(int ac, char **av)
   gprtComputeSetBuffer(compute,"fbPtr",frameBuffer);
   gprtComputeSet2i(compute,"fbSize",fbSize.x,fbSize.y);
   // Build a shader binding table entry for the compute record.
-  gprtBuildSBT(gprt);
+  gprtBuildShaderBindingTable(gprt);
 
   // ##################################################################
   // now that everything is ready: launch it ....

--- a/samples/int00-rayGenOnly/hostCode.cpp
+++ b/samples/int00-rayGenOnly/hostCode.cpp
@@ -82,7 +82,7 @@ int main(int ac, char **av)
                       sizeof(RayGenData),rayGenVars,-1);
 
   // (re-)builds all vulkan programs, with current pipeline settings
-  gprtBuildPrograms(gprt);
+  gprtBuildPipeline(gprt);
 
   // ------------------------------------------------------------------
   // alloc buffers
@@ -102,7 +102,7 @@ int main(int ac, char **av)
   gprtRayGenSetBuffer(rayGen,"fbPtr",frameBuffer);
   gprtRayGenSet2i(rayGen,"fbSize",fbSize.x,fbSize.y);
   // Build a shader binding table entry for the ray generation record.
-  gprtBuildSBT(gprt);
+  gprtBuildShaderBindingTable(gprt);
 
 
   // ##################################################################

--- a/samples/int01-simpleTriangles/hostCode.cpp
+++ b/samples/int01-simpleTriangles/hostCode.cpp
@@ -203,8 +203,8 @@ int main(int ac, char **av)
   // ##################################################################
   // build *SBT* required to trace the groups
   // ##################################################################
-  gprtBuildPrograms(context);
-  gprtBuildSBT(context);
+  gprtBuildPipeline(context);
+  gprtBuildShaderBindingTable(context);
 
   // ##################################################################
   // create a window we can use to display and interact with the image
@@ -289,7 +289,7 @@ int main(int ac, char **av)
       gprtRayGenSet3fv    (rayGen,"camera.dir_du",(float*)&camera_ddu);
       gprtRayGenSet3fv    (rayGen,"camera.dir_dv",(float*)&camera_ddv);
 
-      gprtBuildSBT(context);
+      gprtBuildShaderBindingTable(context);
     }
 
     // Now, trace rays

--- a/samples/int02-simpleAABBs/hostCode.cpp
+++ b/samples/int02-simpleAABBs/hostCode.cpp
@@ -193,8 +193,8 @@ int main(int ac, char **av)
   // ##################################################################
   // build *SBT* required to trace the groups
   // ##################################################################
-  gprtBuildPrograms(context);
-  gprtBuildSBT(context);
+  gprtBuildPipeline(context);
+  gprtBuildShaderBindingTable(context);
 
   // ##################################################################
   // create a window we can use to display and interact with the image
@@ -279,7 +279,7 @@ int main(int ac, char **av)
       gprtRayGenSet3fv    (rayGen,"camera.dir_du",(float*)&camera_ddu);
       gprtRayGenSet3fv    (rayGen,"camera.dir_dv",(float*)&camera_ddv);
 
-      gprtBuildSBT(context);
+      gprtBuildShaderBindingTable(context);
     }
 
     // Now, trace rays

--- a/samples/int04-computeAABBs/hostCode.cpp
+++ b/samples/int04-computeAABBs/hostCode.cpp
@@ -135,7 +135,10 @@ int main(int ac, char **av)
                       sizeof(AABBBoundsData),
                       computeVars,-1);
 
-  gprtBuildPrograms(context);
+  // Note, we'll need to call this again after creating our acceleration 
+  // structures, as acceleration structures will introduce new shader 
+  // binding table records to the pipeline.
+  gprtBuildPipeline(context);
 
   // ------------------------------------------------------------------
   // aabb mesh
@@ -161,7 +164,7 @@ int main(int ac, char **av)
   gprtComputeSetBuffer(boundsProgram, "aabbs", aabbPositionsBuffer);
   
   // compute AABBs in parallel with a compute shader
-  gprtBuildSBT(context, GPRT_SBT_COMPUTE);
+  gprtBuildShaderBindingTable(context, GPRT_SBT_COMPUTE);
   gprtComputeLaunch1D(context,boundsProgram,NUM_VERTICES);
 
   GPRTAccel aabbAccel = gprtAABBAccelCreate(context,1,&aabbGeom);
@@ -191,7 +194,10 @@ int main(int ac, char **av)
   // build *SBT* required to trace the groups
   // ##################################################################
   
-  gprtBuildSBT(context, GPRT_SBT_ALL);
+  // re-build the pipeline to account for newly introduced geometry
+  gprtBuildPipeline(context);
+  gprtBuildShaderBindingTable(context, GPRT_SBT_ALL);
+
 
   // ##################################################################
   // create a window we can use to display and interact with the image
@@ -276,7 +282,7 @@ int main(int ac, char **av)
       gprtRayGenSet3fv    (rayGen,"camera.dir_du",(float*)&camera_ddu);
       gprtRayGenSet3fv    (rayGen,"camera.dir_dv",(float*)&camera_ddv);
       
-      gprtBuildSBT(context, GPRT_SBT_RAYGEN);
+      gprtBuildShaderBindingTable(context, GPRT_SBT_RAYGEN);
     }
 
     // Now, trace rays

--- a/samples/int07-doublePrecision/hostCode.cpp
+++ b/samples/int07-doublePrecision/hostCode.cpp
@@ -121,7 +121,7 @@ int main(int ac, char **av)
     = gprtMissCreate(context,module,"miss",sizeof(MissProgData),
                         missVars,-1);
 
-  gprtBuildPrograms(context);
+  gprtBuildPipeline(context);
 
   // ------------------------------------------------------------------
   // aabb mesh
@@ -147,7 +147,7 @@ int main(int ac, char **av)
   gprtComputeSetBuffer(DPTriangleBoundsProgram, "aabbs", aabbPositionsBuffer);
   
   // compute AABBs in parallel with a compute shader
-  gprtBuildSBT(context, GPRT_SBT_COMPUTE);
+  gprtBuildShaderBindingTable(context, GPRT_SBT_COMPUTE);
   gprtComputeLaunch1D(context,DPTriangleBoundsProgram,double_cube_num_indices);
 
   GPRTAccel aabbAccel = gprtAABBAccelCreate(context,1,&dpCubeGeom);
@@ -205,7 +205,9 @@ int main(int ac, char **av)
   // build *SBT* required to trace the groups
   // ##################################################################
   
-  gprtBuildSBT(context, GPRT_SBT_ALL);
+  // re-build the pipeline to account for newly introduced geometry
+  gprtBuildPipeline(context);
+  gprtBuildShaderBindingTable(context, GPRT_SBT_ALL);
 
   // ##################################################################
   // create a window we can use to display and interact with the image
@@ -289,7 +291,7 @@ int main(int ac, char **av)
       gprtRayGenSet3fv    (rayGen,"camera.dir_00",(float*)&camera_d00);
       gprtRayGenSet3fv    (rayGen,"camera.dir_du",(float*)&camera_ddu);
       gprtRayGenSet3fv    (rayGen,"camera.dir_dv",(float*)&camera_ddv);
-      gprtBuildSBT(context, GPRT_SBT_RAYGEN);
+      gprtBuildShaderBindingTable(context, GPRT_SBT_RAYGEN);
     }
 
     // Now, trace rays

--- a/samples/int08-multipleTLAS/CMakeLists.txt
+++ b/samples/int08-multipleTLAS/CMakeLists.txt
@@ -20,17 +20,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-add_subdirectory(cmd00-rayGenOnly)
-add_subdirectory(cmd01-simpleTriangles)
-add_subdirectory(cmd02-simpleAABBs)
-add_subdirectory(cmd03-computeOnly)
+embed_devicecode(
+  OUTPUT_TARGET
+    int08_deviceCode
+  ENTRY_POINTS
+    simpleRayGen
+  SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/deviceCode.hlsl
+)
 
-add_subdirectory(int00-rayGenOnly)
-add_subdirectory(int01-simpleTriangles)
-add_subdirectory(int02-simpleAABBs)
-
-add_subdirectory(int04-computeAABBs)
-add_subdirectory(int05-computePrimitive)
-
-add_subdirectory(int07-doublePrecision)
-add_subdirectory(int08-multipleTLAS)
+add_executable(int08_multipleTLAS hostCode.cpp)
+target_link_libraries(int08_multipleTLAS
+  PRIVATE
+    int08_deviceCode
+    gprt::gprt
+    glfw
+    ${OPENGL_gl_LIBRARY}
+)

--- a/samples/int08-multipleTLAS/deviceCode.h
+++ b/samples/int08-multipleTLAS/deviceCode.h
@@ -1,0 +1,75 @@
+// MIT License
+
+// Copyright (c) 2022 Nathan V. Morrical
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "gprt.h"
+
+/* variables available to all programs */
+
+
+/* variables for the triangle mesh geometry */
+struct TrianglesGeomData
+{
+  /*! array/buffer of vertex indices */
+  alignas(16) gprt::Buffer index; // vec3i*
+  /*! array/buffer of vertex positions */
+  alignas(16) gprt::Buffer vertex; // vec3f *  
+  /*! base color we use for the entire mesh */
+  alignas(16) float3 color;
+};
+
+/* variables for the triangle mesh geometry */
+struct TetrahedraGeomData
+{
+  /*! array/buffer of vertex indices */
+  alignas(16) gprt::Buffer index; // vec4i*
+  /*! array/buffer of vertex positions */
+  alignas(16) gprt::Buffer vertex; // vec3f *  
+  /*! base color we use for the entire mesh */
+  alignas(16) float3 color;
+};
+
+struct RayGenData
+{
+  alignas(16) gprt::Buffer fbPtr;
+
+  alignas(8) int2 fbSize;
+
+  /* Acceleration structure containing only triangle geometry */
+  alignas(16) gprt::Accel meshes;
+
+  /* Acceleration structure containing only tetrahedra */
+  alignas(16) gprt::Accel cells;
+
+  struct { 
+    alignas(16) float3 pos;   
+    alignas(16) float3 dir_00;
+    alignas(16) float3 dir_du;
+    alignas(16) float3 dir_dv;
+  } camera;
+};
+
+/* variables for the miss program */
+struct MissProgData
+{
+  alignas(16) float3  color0;
+  alignas(16) float3  color1;
+};

--- a/samples/int08-multipleTLAS/deviceCode.h
+++ b/samples/int08-multipleTLAS/deviceCode.h
@@ -43,8 +43,6 @@ struct TetrahedraGeomData
   alignas(16) gprt::Buffer index; // vec4i*
   /*! array/buffer of vertex positions */
   alignas(16) gprt::Buffer vertex; // vec3f *  
-  /*! base color we use for the entire mesh */
-  alignas(16) float3 color;
 };
 
 struct RayGenData

--- a/samples/int08-multipleTLAS/deviceCode.hlsl
+++ b/samples/int08-multipleTLAS/deviceCode.hlsl
@@ -1,0 +1,102 @@
+// MIT License
+
+// Copyright (c) 2022 Nathan V. Morrical
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "deviceCode.h"
+#include "gprt.h"
+
+struct Payload
+{
+  float3 color;
+};
+
+GPRT_RAYGEN_PROGRAM(simpleRayGen, (RayGenData, record))
+{
+  Payload payload;
+  uint2 pixelID = DispatchRaysIndex().xy;
+  float2 screen = (float2(pixelID) + 
+                  float2(.5f, .5f)) / float2(record.fbSize);
+
+  RayDesc rayDesc;
+  rayDesc.Origin = record.camera.pos;
+  rayDesc.Direction = 
+    normalize(record.camera.dir_00
+    + screen.x * record.camera.dir_du
+    + screen.y * record.camera.dir_dv
+  );
+  rayDesc.TMin = 0.001;
+  rayDesc.TMax = 10000.0;
+  RaytracingAccelerationStructure meshes = gprt::getAccelHandle(record.meshes);
+  TraceRay(
+    meshes, // the tree
+    RAY_FLAG_FORCE_OPAQUE, // ray flags
+    0xff, // instance inclusion mask
+    0, // ray type
+    1, // number of ray types
+    0, // miss type
+    rayDesc, // the ray to trace
+    payload // the payload IO
+  );
+
+  const int fbOfs = pixelID.x + record.fbSize.x * pixelID.y;
+  gprt::store(record.fbPtr, fbOfs, gprt::make_rgba(payload.color));
+}
+
+struct TriangleAttributes {
+  float2 bc;
+};
+
+GPRT_CLOSEST_HIT_PROGRAM(TriangleMesh, (TrianglesGeomData, record), (Payload, payload), (TriangleAttributes, attributes))
+{
+  // compute normal:
+  uint   primID = PrimitiveIndex();
+  int3   index  = gprt::load<int3>(record.index, primID);
+  float3 A      = gprt::load<float3>(record.vertex, index.x);
+  float3 B      = gprt::load<float3>(record.vertex, index.y);
+  float3 C      = gprt::load<float3>(record.vertex, index.z);
+  float3 Ng     = normalize(cross(B-A,C-A));
+  float3 rayDir = WorldRayDirection();
+  payload.color = (.2f + .8f * abs(dot(rayDir,Ng))) * record.color;
+}
+
+struct TetrahedraAttributes {
+  float2 bc;
+};
+
+GPRT_CLOSEST_HIT_PROGRAM(TetrahedralMesh, (TetrahedraGeomData, record), (Payload, payload), (TetrahedraAttributes, attributes))
+{
+  // // compute normal:
+  // uint   primID = PrimitiveIndex();
+  // int3   index  = gprt::load<int3>(record.index, primID);
+  // float3 A      = gprt::load<float3>(record.vertex, index.x);
+  // float3 B      = gprt::load<float3>(record.vertex, index.y);
+  // float3 C      = gprt::load<float3>(record.vertex, index.z);
+  // float3 Ng     = normalize(cross(B-A,C-A));
+  // float3 rayDir = WorldRayDirection();
+  // payload.color = (.2f + .8f * abs(dot(rayDir,Ng))) * record.color;
+}
+
+GPRT_MISS_PROGRAM(miss, (MissProgData, record), (Payload, payload))
+{
+  uint2 pixelID = DispatchRaysIndex().xy;  
+  int pattern = (pixelID.x / 8) ^ (pixelID.y/8);
+  payload.color = (pattern & 1) ? record.color1 : record.color0;
+}

--- a/samples/int08-multipleTLAS/deviceCode.hlsl
+++ b/samples/int08-multipleTLAS/deviceCode.hlsl
@@ -81,7 +81,7 @@ GPRT_RAYGEN_PROGRAM(simpleRayGen, (RayGenData, record))
   RaytracingAccelerationStructure cells = gprt::getAccelHandle(record.cells);
   float3 color = float3(0.0, 0.0, 0.0);
   float alpha = 0.0;
-  for (float t = rayDesc.TMin; t < rayDesc.TMax; t += .05f) {
+  for (float t = rayDesc.TMin; t < rayDesc.TMax; t += .02f) {
     if (alpha > .99f) break;
     float3 x = rayDesc.Origin + rayDesc.Direction * t;
 

--- a/samples/int08-multipleTLAS/deviceCode.hlsl
+++ b/samples/int08-multipleTLAS/deviceCode.hlsl
@@ -175,7 +175,7 @@ GPRT_INTERSECTION_PROGRAM(TetrahedralMesh, (TetrahedraGeomData, record))
 
 GPRT_CLOSEST_HIT_PROGRAM(TetrahedralMesh, (TetrahedraGeomData, record), (Payload, payload), (TetrahedraAttributes, attributes))
 {
-  payload.color = float4(1.0, 0.0, 0.0, .1);
+  payload.color = float4(attributes.bc.x, attributes.bc.y, attributes.bc.z, .1);
   payload.tHit = 1.f;
 }
 

--- a/samples/int08-multipleTLAS/deviceCode.hlsl
+++ b/samples/int08-multipleTLAS/deviceCode.hlsl
@@ -81,7 +81,8 @@ GPRT_RAYGEN_PROGRAM(simpleRayGen, (RayGenData, record))
   RaytracingAccelerationStructure cells = gprt::getAccelHandle(record.cells);
   float3 color = float3(0.0, 0.0, 0.0);
   float alpha = 0.0;
-  for (float t = rayDesc.TMin; t < rayDesc.TMax  && alpha < .99f; t += .05f) {
+  for (float t = rayDesc.TMin; t < rayDesc.TMax; t += .05f) {
+    if (alpha > .99f) break;
     float3 x = rayDesc.Origin + rayDesc.Direction * t;
 
     RayDesc pointDesc;

--- a/samples/int08-multipleTLAS/deviceCode.hlsl
+++ b/samples/int08-multipleTLAS/deviceCode.hlsl
@@ -25,8 +25,19 @@
 
 struct Payload
 {
-  float3 color;
+  float4 color;
+  float tHit;
 };
+
+inline float3 over(float3 Cin, float3 Cx, float Ain, float Ax)
+{
+  return Cin + Cx*Ax*(1.f-Ain);
+} 
+
+inline float over(float Ain, float Ax)
+{
+  return Ain + (1.f-Ain)*Ax;
+}
 
 GPRT_RAYGEN_PROGRAM(simpleRayGen, (RayGenData, record))
 {
@@ -35,6 +46,7 @@ GPRT_RAYGEN_PROGRAM(simpleRayGen, (RayGenData, record))
   float2 screen = (float2(pixelID) + 
                   float2(.5f, .5f)) / float2(record.fbSize);
 
+  // Generate ray
   RayDesc rayDesc;
   rayDesc.Origin = record.camera.pos;
   rayDesc.Direction = 
@@ -42,8 +54,10 @@ GPRT_RAYGEN_PROGRAM(simpleRayGen, (RayGenData, record))
     + screen.x * record.camera.dir_du
     + screen.y * record.camera.dir_dv
   );
-  rayDesc.TMin = 0.001;
-  rayDesc.TMax = 10000.0;
+  rayDesc.TMin = 0.0;
+  rayDesc.TMax = 10.0;
+  
+  // Trace ray against surface
   RaytracingAccelerationStructure meshes = gprt::getAccelHandle(record.meshes);
   TraceRay(
     meshes, // the tree
@@ -55,9 +69,49 @@ GPRT_RAYGEN_PROGRAM(simpleRayGen, (RayGenData, record))
     rayDesc, // the ray to trace
     payload // the payload IO
   );
+  
+  float3 backgroundColor = payload.color.rgb;
+
+  // Replace background color if we hit a surface, and update tHit distance
+  if (payload.tHit > 0.0) {
+    rayDesc.TMax = payload.tHit;
+  }
+
+  // Next, march ray through volume
+  RaytracingAccelerationStructure cells = gprt::getAccelHandle(record.cells);
+  float3 color = float3(0.0, 0.0, 0.0);
+  float alpha = 0.0;
+  for (float t = rayDesc.TMin; t < rayDesc.TMax  && alpha < .99f; t += .05f) {
+    float3 x = rayDesc.Origin + rayDesc.Direction * t;
+
+    RayDesc pointDesc;
+    pointDesc.Origin = x;
+    pointDesc.Direction = float3(1.0, 1.0, 1.0);
+    pointDesc.TMin = pointDesc.TMax = 0.0;
+
+    TraceRay(
+      cells, // the tree
+      RAY_FLAG_FORCE_OPAQUE, // ray flags
+      0xff, // instance inclusion mask
+      0, // ray type
+      1, // number of ray types
+      0, // miss type
+      pointDesc, // the ray to trace
+      payload // the payload IO
+    );
+
+    // Composite volumetric color
+    if (payload.tHit > 0.0) 
+    {
+      color = over(color, payload.color.rgb, alpha, payload.color.w);
+      alpha = over(alpha, payload.color.w);
+    }
+  }
+
+  float3 finalColor = over(color, backgroundColor, alpha, 1.0);
 
   const int fbOfs = pixelID.x + record.fbSize.x * pixelID.y;
-  gprt::store(record.fbPtr, fbOfs, gprt::make_rgba(payload.color));
+  gprt::store(record.fbPtr, fbOfs, gprt::make_rgba(finalColor));
 }
 
 struct TriangleAttributes {
@@ -74,29 +128,61 @@ GPRT_CLOSEST_HIT_PROGRAM(TriangleMesh, (TrianglesGeomData, record), (Payload, pa
   float3 C      = gprt::load<float3>(record.vertex, index.z);
   float3 Ng     = normalize(cross(B-A,C-A));
   float3 rayDir = WorldRayDirection();
-  payload.color = (.2f + .8f * abs(dot(rayDir,Ng))) * record.color;
+  payload.color = (.2f + .8f * abs(dot(rayDir,Ng))) * float4(record.color.x, record.color.y, record.color.z, 1.0);
+  payload.tHit = RayTCurrent();
 }
 
 struct TetrahedraAttributes {
-  float2 bc;
+  float4 bc;
 };
+
+/* computes the (oriented) volume of the tet given by the four vertices */
+inline float volume(in float3 P, in float3 A, in float3 B, in float3 C)
+{
+  return dot(P - A, cross(B - A, C - A));
+}
+
+GPRT_INTERSECTION_PROGRAM(TetrahedralMesh, (TetrahedraGeomData, record))
+{
+  uint   primID = PrimitiveIndex();
+  int4   index  = gprt::load<int4>(record.index, primID);
+  float3 P0      = gprt::load<float3>(record.vertex, index.x);
+  float3 P1      = gprt::load<float3>(record.vertex, index.y);
+  float3 P2      = gprt::load<float3>(record.vertex, index.z);
+  float3 P3      = gprt::load<float3>(record.vertex, index.w);
+
+  float3 P      = WorldRayOrigin();
+  float vol_all = volume(P0, P1, P3, P2);
+  if (vol_all == 0.f) return;
+
+  const float bary0 = volume(P, P1, P3, P2) / vol_all;
+  if (bary0 < 0.f) return;
+
+  const float bary1 = volume(P, P0, P2, P3) / vol_all;
+  if (bary1 < 0.f) return;
+
+  const float bary2 = volume(P, P0, P3, P1) / vol_all;
+  if (bary2 < 0.f) return;
+
+  const float bary3 = volume(P, P0, P1, P2) / vol_all;
+  if (bary3 < 0.f) return;
+
+  TetrahedraAttributes attr;
+  attr.bc = float4(bary0, bary1, bary2, bary3);
+  ReportHit(0.0, /*hitKind*/ 0, attr);
+}
 
 GPRT_CLOSEST_HIT_PROGRAM(TetrahedralMesh, (TetrahedraGeomData, record), (Payload, payload), (TetrahedraAttributes, attributes))
 {
-  // // compute normal:
-  // uint   primID = PrimitiveIndex();
-  // int3   index  = gprt::load<int3>(record.index, primID);
-  // float3 A      = gprt::load<float3>(record.vertex, index.x);
-  // float3 B      = gprt::load<float3>(record.vertex, index.y);
-  // float3 C      = gprt::load<float3>(record.vertex, index.z);
-  // float3 Ng     = normalize(cross(B-A,C-A));
-  // float3 rayDir = WorldRayDirection();
-  // payload.color = (.2f + .8f * abs(dot(rayDir,Ng))) * record.color;
+  payload.color = float4(1.0, 0.0, 0.0, .1);
+  payload.tHit = 1.f;
 }
 
 GPRT_MISS_PROGRAM(miss, (MissProgData, record), (Payload, payload))
 {
   uint2 pixelID = DispatchRaysIndex().xy;  
   int pattern = (pixelID.x / 8) ^ (pixelID.y/8);
-  payload.color = (pattern & 1) ? record.color1 : record.color0;
+  float3 color = (pattern & 1) ? record.color1 : record.color0;
+  payload.color = float4(color, 1.0);
+  payload.tHit = -1.0;
 }

--- a/samples/int08-multipleTLAS/hostCode.cpp
+++ b/samples/int08-multipleTLAS/hostCode.cpp
@@ -100,7 +100,7 @@ struct TetrahedralMesh {
 const int2 fbSize = {800,600};
 GLuint fbTexture {0};
 
-float3 lookFrom = {0.f,-2.f,1.f};
+float3 lookFrom = {0.f,-4.f,1.f};
 float3 lookAt = {0.f,0.f,0.f};
 float3 lookUp = {0.f,0.f,1.f};
 float cosFovy = 0.66f;
@@ -146,6 +146,8 @@ int main(int ac, char **av)
                         GPRT_AABBS,
                         sizeof(TrianglesGeomData),
                         tetrahedraGeomVars,-1);
+  gprtGeomTypeSetIntersectionProg(tetrahedraGeomType,0,
+                           module,"TetrahedralMesh");
   gprtGeomTypeSetClosestHitProg(tetrahedraGeomType,0,
                            module,"TetrahedralMesh");
 
@@ -205,17 +207,19 @@ int main(int ac, char **av)
   // ------------------------------------------------------------------
   // the group/accel for that mesh
   // ------------------------------------------------------------------
-  GPRTAccel trianglesAccel = gprtTrianglesAccelCreate(context,1,&trianglesGeom);
-  gprtAccelBuild(context, trianglesAccel);
-  GPRTAccel trianglesTLAS = gprtInstanceAccelCreate(context,1,&trianglesAccel);
-  gprtInstanceAccelSetTransforms(trianglesTLAS, triangleTransformBuffer);
-  gprtAccelBuild(context, trianglesTLAS);
-
   GPRTAccel tetrahedraAccel = gprtAABBAccelCreate(context,1,&tetrahedraGeom);
   gprtAccelBuild(context, tetrahedraAccel);
   GPRTAccel tetrahedraTLAS = gprtInstanceAccelCreate(context,1,&tetrahedraAccel);
   gprtInstanceAccelSetTransforms(tetrahedraTLAS, tetrahedraTransformBuffer);
   gprtAccelBuild(context, tetrahedraTLAS);
+
+  GPRTAccel trianglesAccel = gprtTrianglesAccelCreate(context,1,&trianglesGeom);
+  gprtAccelBuild(context, trianglesAccel);
+  GPRTAccel trianglesTLAS = gprtInstanceAccelCreate(context,1,&trianglesAccel);
+  gprtInstanceAccelSetTransforms(trianglesTLAS, triangleTransformBuffer);
+  gprtAccelBuild(context, trianglesTLAS);
+  
+
 
   // ##################################################################
   // set miss and raygen program required for SBT

--- a/samples/int08-multipleTLAS/hostCode.cpp
+++ b/samples/int08-multipleTLAS/hostCode.cpp
@@ -1,0 +1,445 @@
+// MIT License
+
+// Copyright (c) 2022 Nathan V. Morrical
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// This program sets up a single geometric object, a mesh for a cube, and
+// its acceleration structure, then ray traces it.
+
+// public GPRT API
+#include <gprt.h>
+
+// our device-side data structures
+#include "deviceCode.h"
+
+// library for windowing
+#include <GLFW/glfw3.h>
+
+#define LOG(message)                                            \
+  std::cout << GPRT_TERMINAL_BLUE;                               \
+  std::cout << "#gprt.sample(main): " << message << std::endl;   \
+  std::cout << GPRT_TERMINAL_DEFAULT;
+#define LOG_OK(message)                                         \
+  std::cout << GPRT_TERMINAL_LIGHT_BLUE;                         \
+  std::cout << "#gprt.sample(main): " << message << std::endl;   \
+  std::cout << GPRT_TERMINAL_DEFAULT;
+
+extern GPRTProgram int08_deviceCode;
+
+struct TriangleMesh {
+  const int NUM_VERTICES = 4;
+  float3 vertices[4] =
+    {
+      { -1.f,-1.f,-1.f },
+      { +1.f,-1.f,-1.f },
+      { -1.f,+1.f,-1.f },
+      { +1.f,+1.f,-1.f }
+    };
+
+  const int NUM_INDICES = 2;
+  int3 indices[2] =
+    {
+      { 0,1,3 }, { 2,3,0 }
+    };
+
+  float transform[3][4] =
+    {
+      1.0f, 0.0f, 0.0f, 0.0f,
+      0.0f, 1.0f, 0.0f, 0.0f,
+      0.0f, 0.0f, 1.0f, 0.0f
+    };
+} triangleMesh;
+
+struct TetrahedralMesh {
+  const int NUM_VERTICES = 4;
+  float3 vertices[8] =
+    {
+      { cosf(2.0944 * 0), sinf(2.0944 * 0),-1.f },
+      { cosf(2.0944 * 1), sinf(2.0944 * 1),-1.f },
+      { cosf(2.0944 * 2), sinf(2.0944 * 2),-1.f },
+      { 0.f,0.f,1.f },
+    };
+
+  const int NUM_INDICES = 1;
+  int4 indices[1] =
+    {
+      { 0,1,2,3}
+    };
+
+  float3 aabbs[2] = 
+    {
+      {-1.0, -1.0, -1.0}, {1.0, 1.0, 1.0}
+    };
+
+  float transform[3][4] =
+    {
+      1.0f, 0.0f, 0.0f, 0.0f,
+      0.0f, 1.0f, 0.0f, 0.0f,
+      0.0f, 0.0f, 1.0f, 0.0f
+    };
+} tetrahedralMesh;
+
+// initial image resolution
+const int2 fbSize = {800,600};
+GLuint fbTexture {0};
+
+float3 lookFrom = {0.f,-2.f,1.f};
+float3 lookAt = {0.f,0.f,0.f};
+float3 lookUp = {0.f,0.f,1.f};
+float cosFovy = 0.66f;
+
+#include <iostream>
+int main(int ac, char **av)
+{
+  LOG("gprt example '" << av[0] << "' starting up");
+
+  // create a context on the first device:
+  GPRTContext context = gprtContextCreate(nullptr,1);
+  GPRTModule module = gprtModuleCreate(context,int08_deviceCode);
+
+  // ##################################################################
+  // set up all the *GEOMETRY* graph we want to render
+  // ##################################################################
+
+  // -------------------------------------------------------
+  // declare geometry type
+  // -------------------------------------------------------
+  GPRTVarDecl trianglesGeomVars[] = {
+    { "index",  GPRT_BUFFER, GPRT_OFFSETOF(TrianglesGeomData,index)},
+    { "vertex", GPRT_BUFFER, GPRT_OFFSETOF(TrianglesGeomData,vertex)},
+    { "color",  GPRT_FLOAT3, GPRT_OFFSETOF(TrianglesGeomData,color)},
+    { /* sentinel to mark end of list */ }
+  };
+  GPRTGeomType trianglesGeomType
+    = gprtGeomTypeCreate(context,
+                        GPRT_TRIANGLES,
+                        sizeof(TrianglesGeomData),
+                        trianglesGeomVars,-1);
+  gprtGeomTypeSetClosestHitProg(trianglesGeomType,0,
+                           module,"TriangleMesh");
+
+  GPRTVarDecl tetrahedraGeomVars[] = {
+    { "index",  GPRT_BUFFER, GPRT_OFFSETOF(TetrahedraGeomData,index)},
+    { "vertex", GPRT_BUFFER, GPRT_OFFSETOF(TetrahedraGeomData,vertex)},
+    { "color",  GPRT_FLOAT3, GPRT_OFFSETOF(TetrahedraGeomData,color)},
+    { /* sentinel to mark end of list */ }
+  };
+  GPRTGeomType tetrahedraGeomType
+    = gprtGeomTypeCreate(context,
+                        GPRT_AABBS,
+                        sizeof(TrianglesGeomData),
+                        tetrahedraGeomVars,-1);
+  gprtGeomTypeSetClosestHitProg(tetrahedraGeomType,0,
+                           module,"TetrahedralMesh");
+
+  // ##################################################################
+  // set up all the *GEOMS* we want to run that code on
+  // ##################################################################
+
+  LOG("building geometries ...");
+
+  // ------------------------------------------------------------------
+  // Meshes
+  // ------------------------------------------------------------------
+  GPRTBuffer triangleVertexBuffer
+    = gprtHostBufferCreate(context,GPRT_FLOAT3,
+        triangleMesh.NUM_VERTICES,triangleMesh.vertices);
+  GPRTBuffer triangleIndexBuffer
+    = gprtDeviceBufferCreate(context,GPRT_INT3,
+        triangleMesh.NUM_INDICES,triangleMesh.indices);
+  GPRTBuffer triangleTransformBuffer
+    = gprtDeviceBufferCreate(context,GPRT_TRANSFORM,
+        1,triangleMesh.transform);
+  
+  GPRTBuffer tetrahedraVertexBuffer
+    = gprtHostBufferCreate(context,GPRT_FLOAT3,
+        tetrahedralMesh.NUM_VERTICES,tetrahedralMesh.vertices);
+  GPRTBuffer tetrahedraIndexBuffer
+    = gprtDeviceBufferCreate(context,GPRT_INT4,
+        tetrahedralMesh.NUM_INDICES,tetrahedralMesh.indices);
+  GPRTBuffer tetrahedraAABBBuffer
+    = gprtHostBufferCreate(context,GPRT_FLOAT3,
+        tetrahedralMesh.NUM_INDICES * 2,tetrahedralMesh.aabbs);
+  GPRTBuffer tetrahedraTransformBuffer
+    = gprtDeviceBufferCreate(context,GPRT_TRANSFORM,
+        1,tetrahedralMesh.transform);
+
+  GPRTBuffer frameBuffer
+    = gprtHostBufferCreate(context,GPRT_INT,fbSize.x*fbSize.y);
+
+  GPRTGeom trianglesGeom
+    = gprtGeomCreate(context,trianglesGeomType);
+  gprtTrianglesSetVertices(trianglesGeom,triangleVertexBuffer,
+                           triangleMesh.NUM_VERTICES,sizeof(float3),0);
+  gprtTrianglesSetIndices(trianglesGeom,triangleIndexBuffer,
+                          triangleMesh.NUM_INDICES,sizeof(int3),0);
+  gprtGeomSetBuffer(trianglesGeom,"vertex",triangleVertexBuffer);
+  gprtGeomSetBuffer(trianglesGeom,"index",triangleIndexBuffer);
+  gprtGeomSet3f(trianglesGeom,"color",0,1,0);
+
+  GPRTGeom tetrahedraGeom
+    = gprtGeomCreate(context,tetrahedraGeomType);
+  gprtAABBsSetPositions(tetrahedraGeom,tetrahedraAABBBuffer,
+                           tetrahedralMesh.NUM_INDICES,sizeof(float3) * 2,0);
+  gprtGeomSetBuffer(tetrahedraGeom,"vertex",tetrahedraVertexBuffer);
+  gprtGeomSetBuffer(tetrahedraGeom,"index",tetrahedraIndexBuffer);
+  gprtGeomSet3f(tetrahedraGeom,"color",0,1,0);
+
+  // ------------------------------------------------------------------
+  // the group/accel for that mesh
+  // ------------------------------------------------------------------
+  GPRTAccel trianglesAccel = gprtTrianglesAccelCreate(context,1,&trianglesGeom);
+  gprtAccelBuild(context, trianglesAccel);
+  GPRTAccel trianglesTLAS = gprtInstanceAccelCreate(context,1,&trianglesAccel);
+  gprtInstanceAccelSetTransforms(trianglesTLAS, triangleTransformBuffer);
+  gprtAccelBuild(context, trianglesTLAS);
+
+  GPRTAccel tetrahedraAccel = gprtAABBAccelCreate(context,1,&tetrahedraGeom);
+  gprtAccelBuild(context, tetrahedraAccel);
+  GPRTAccel tetrahedraTLAS = gprtInstanceAccelCreate(context,1,&tetrahedraAccel);
+  gprtInstanceAccelSetTransforms(tetrahedraTLAS, tetrahedraTransformBuffer);
+  gprtAccelBuild(context, tetrahedraTLAS);
+
+  // ##################################################################
+  // set miss and raygen program required for SBT
+  // ##################################################################
+
+  // -------------------------------------------------------
+  // set up miss prog
+  // -------------------------------------------------------
+  GPRTVarDecl missProgVars[]
+    = {
+    { "color0", GPRT_FLOAT3, GPRT_OFFSETOF(MissProgData,color0)},
+    { "color1", GPRT_FLOAT3, GPRT_OFFSETOF(MissProgData,color1)},
+    { /* sentinel to mark end of list */ }
+  };
+  // ----------- create object  ----------------------------
+  GPRTMiss miss
+    = gprtMissCreate(context,module,"miss",sizeof(MissProgData),
+                        missProgVars,-1);
+
+  // ----------- set variables  ----------------------------
+  gprtMissSet3f(miss,"color0",0.1f,0.1f,0.1f);
+  gprtMissSet3f(miss,"color1",.0f,.0f,.0f);
+
+  // -------------------------------------------------------
+  // set up ray gen program
+  // -------------------------------------------------------
+  GPRTVarDecl rayGenVars[] = {
+    { "fbSize",        GPRT_INT2,   GPRT_OFFSETOF(RayGenData,fbSize)},
+    { "fbPtr",         GPRT_BUFFER, GPRT_OFFSETOF(RayGenData,fbPtr)},
+    { "meshes",        GPRT_ACCEL,  GPRT_OFFSETOF(RayGenData,meshes)},
+    { "cells",         GPRT_ACCEL,  GPRT_OFFSETOF(RayGenData,cells)},
+    { "camera.pos",    GPRT_FLOAT3, GPRT_OFFSETOF(RayGenData,camera.pos)},
+    { "camera.dir_00", GPRT_FLOAT3, GPRT_OFFSETOF(RayGenData,camera.dir_00)},
+    { "camera.dir_du", GPRT_FLOAT3, GPRT_OFFSETOF(RayGenData,camera.dir_du)},
+    { "camera.dir_dv", GPRT_FLOAT3, GPRT_OFFSETOF(RayGenData,camera.dir_dv)},
+    { /* sentinel to mark end of list */ }
+  };
+
+  // ----------- create object  ----------------------------
+  GPRTRayGen rayGen
+    = gprtRayGenCreate(context,module,"simpleRayGen",
+                      sizeof(RayGenData),
+                      rayGenVars,-1);
+
+  // ----------- set variables  ----------------------------
+  gprtRayGenSetBuffer(rayGen,"fbPtr", frameBuffer);
+  gprtRayGenSet2iv(rayGen,"fbSize", (int32_t*)&fbSize);
+  gprtRayGenSetAccel(rayGen,"meshes", trianglesTLAS);
+  gprtRayGenSetAccel(rayGen,"cells", tetrahedraTLAS);
+
+  // ##################################################################
+  // build *SBT* required to trace the groups
+  // ##################################################################
+  gprtBuildPrograms(context);
+  gprtBuildSBT(context);
+
+  // ##################################################################
+  // create a window we can use to display and interact with the image
+  // ##################################################################
+  if (!glfwInit())
+    // Initialization failed
+    throw std::runtime_error("Can't initialize GLFW");
+
+  auto error_callback = [](int error, const char* description)
+  {
+    fprintf(stderr, "Error: %s\n", description);
+  };
+  glfwSetErrorCallback(error_callback);
+
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+  glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
+  GLFWwindow* window = glfwCreateWindow(fbSize.x, fbSize.y,
+    "Int08 Multiple TLAS", NULL, NULL);
+  if (!window) throw std::runtime_error("Window or OpenGL context creation failed");
+  glfwMakeContextCurrent(window);
+
+  // ##################################################################
+  // now that everything is ready: launch it ....
+  // ##################################################################
+
+  LOG("launching ...");
+
+  bool firstFrame = true;
+  double xpos = 0.f, ypos = 0.f;
+  double lastxpos, lastypos;
+  while (!glfwWindowShouldClose(window))
+  {
+    float speed = .001f;
+    lastxpos = xpos;
+    lastypos = ypos;
+    glfwGetCursorPos(window, &xpos, &ypos);
+    if (firstFrame) {
+      lastxpos = xpos;
+      lastypos = ypos;
+    }
+    int state = glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_LEFT);
+
+    // If we click the mouse, we should rotate the camera
+    if (state == GLFW_PRESS || firstFrame)
+    {
+      firstFrame = false;
+      float4 position = {lookFrom.x, lookFrom.y, lookFrom.z, 1.f};
+      float4 pivot = {lookAt.x, lookAt.y, lookAt.z, 1.0};
+      #define M_PI 3.1415926f
+
+      // step 1 : Calculate the amount of rotation given the mouse movement.
+      float deltaAngleX = (2 * M_PI / fbSize.x);
+      float deltaAngleY = (M_PI / fbSize.y);
+      float xAngle = (lastxpos - xpos) * deltaAngleX;
+      float yAngle = (lastypos - ypos) * deltaAngleY;
+
+      // step 2: Rotate the camera around the pivot point on the first axis.
+      float4x4 rotationMatrixX = rotation_matrix(rotation_quat(lookUp, xAngle));
+      position = (mul(rotationMatrixX, (position - pivot))) + pivot;
+
+      // step 3: Rotate the camera around the pivot point on the second axis.
+      float3 lookRight = cross(lookUp, normalize(pivot - position).xyz());
+      float4x4 rotationMatrixY = rotation_matrix(rotation_quat(lookRight, yAngle));
+      lookFrom = ((mul(rotationMatrixY, (position - pivot))) + pivot).xyz();
+
+      // ----------- compute variable values  ------------------
+      float3 camera_pos = lookFrom;
+      float3 camera_d00
+        = normalize(lookAt-lookFrom);
+      float aspect = float(fbSize.x) / float(fbSize.y);
+      float3 camera_ddu
+        = cosFovy * aspect * normalize(cross(camera_d00,lookUp));
+      float3 camera_ddv
+        = cosFovy * normalize(cross(camera_ddu,camera_d00));
+      camera_d00 -= 0.5f * camera_ddu;
+      camera_d00 -= 0.5f * camera_ddv;
+
+      // ----------- set variables  ----------------------------
+      gprtRayGenSet3fv    (rayGen,"camera.pos",   (float*)&camera_pos);
+      gprtRayGenSet3fv    (rayGen,"camera.dir_00",(float*)&camera_d00);
+      gprtRayGenSet3fv    (rayGen,"camera.dir_du",(float*)&camera_ddu);
+      gprtRayGenSet3fv    (rayGen,"camera.dir_dv",(float*)&camera_ddv);
+
+      gprtBuildSBT(context);
+    }
+
+    // Now, trace rays
+    gprtRayGenLaunch2D(context,rayGen,fbSize.x,fbSize.y);
+
+    // Render results to screen
+    void* pixels = gprtBufferGetPointer(frameBuffer);
+    if (fbTexture == 0)
+      glGenTextures(1, &fbTexture);
+
+    glBindTexture(GL_TEXTURE_2D, fbTexture);
+    GLenum texFormat = GL_RGBA;
+    GLenum texelType = GL_UNSIGNED_BYTE;
+    glTexImage2D(GL_TEXTURE_2D, 0, texFormat, fbSize.x, fbSize.y, 0, GL_RGBA,
+                  texelType, pixels);
+
+    glDisable(GL_LIGHTING);
+    glColor3f(1, 1, 1);
+
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
+
+    glEnable(GL_TEXTURE_2D);
+    glBindTexture(GL_TEXTURE_2D, fbTexture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+    glDisable(GL_DEPTH_TEST);
+
+    glViewport(0, 0, fbSize.x, fbSize.y);
+
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    glOrtho(0.f, (float)fbSize.x, 0.0, (float)fbSize.y, -1.f, 1.f);
+
+    glBegin(GL_QUADS);
+    {
+      glTexCoord2f(0.f, 0.f);
+      glVertex3f(0.f, 0.f, 0.f);
+
+      glTexCoord2f(0.f, 1.f);
+      glVertex3f(0.f, (float)fbSize.y, 0.f);
+
+      glTexCoord2f(1.f, 1.f);
+      glVertex3f((float)fbSize.x, (float)fbSize.y, 0.f);
+
+      glTexCoord2f(1.f, 0.f);
+      glVertex3f((float)fbSize.x, 0.f, 0.f);
+    }
+    glEnd();
+
+    glfwSwapBuffers(window);
+    glfwPollEvents();
+  }
+
+  // ##################################################################
+  // and finally, clean up
+  // ##################################################################
+
+  LOG("cleaning up ...");
+
+  glfwDestroyWindow(window);
+  glfwTerminate();
+
+  gprtBufferDestroy(triangleVertexBuffer);
+  gprtBufferDestroy(triangleIndexBuffer);
+  gprtBufferDestroy(triangleTransformBuffer);
+  gprtBufferDestroy(tetrahedraVertexBuffer);
+  gprtBufferDestroy(tetrahedraIndexBuffer);
+  gprtBufferDestroy(tetrahedraAABBBuffer);
+  gprtBufferDestroy(tetrahedraTransformBuffer);
+  gprtBufferDestroy(frameBuffer);
+  gprtRayGenDestroy(rayGen);
+  gprtMissDestroy(miss);
+  gprtAccelDestroy(trianglesAccel);
+  gprtAccelDestroy(tetrahedraAccel);
+  gprtAccelDestroy(trianglesTLAS);
+  gprtAccelDestroy(tetrahedraTLAS);
+  gprtGeomDestroy(trianglesGeom);
+  gprtGeomTypeDestroy(trianglesGeomType);
+  gprtGeomDestroy(tetrahedraGeom);
+  gprtGeomTypeDestroy(tetrahedraGeomType);
+  gprtModuleDestroy(module);
+  gprtContextDestroy(context);
+
+  LOG_OK("seems all went OK; app is done, this should be the last output ...");
+}

--- a/samples/int08-multipleTLAS/hostCode.cpp
+++ b/samples/int08-multipleTLAS/hostCode.cpp
@@ -47,10 +47,10 @@ struct TriangleMesh {
   const int NUM_VERTICES = 4;
   float3 vertices[4] =
     {
-      { -1.f,-1.f,-1.f },
-      { +1.f,-1.f,-1.f },
-      { -1.f,+1.f,-1.f },
-      { +1.f,+1.f,-1.f }
+      { -2.f,-2.f,-1.f },
+      { +2.f,-2.f,-1.f },
+      { -2.f,+2.f,-1.f },
+      { +2.f,+2.f,-1.f }
     };
 
   const int NUM_INDICES = 2;
@@ -100,7 +100,7 @@ struct TetrahedralMesh {
 const int2 fbSize = {800,600};
 GLuint fbTexture {0};
 
-float3 lookFrom = {0.f,-4.f,1.f};
+float3 lookFrom = {0.f,-5.f,1.f};
 float3 lookAt = {0.f,0.f,0.f};
 float3 lookUp = {0.f,0.f,1.f};
 float cosFovy = 0.66f;
@@ -138,7 +138,6 @@ int main(int ac, char **av)
   GPRTVarDecl tetrahedraGeomVars[] = {
     { "index",  GPRT_BUFFER, GPRT_OFFSETOF(TetrahedraGeomData,index)},
     { "vertex", GPRT_BUFFER, GPRT_OFFSETOF(TetrahedraGeomData,vertex)},
-    { "color",  GPRT_FLOAT3, GPRT_OFFSETOF(TetrahedraGeomData,color)},
     { /* sentinel to mark end of list */ }
   };
   GPRTGeomType tetrahedraGeomType
@@ -194,7 +193,7 @@ int main(int ac, char **av)
                           triangleMesh.NUM_INDICES,sizeof(int3),0);
   gprtGeomSetBuffer(trianglesGeom,"vertex",triangleVertexBuffer);
   gprtGeomSetBuffer(trianglesGeom,"index",triangleIndexBuffer);
-  gprtGeomSet3f(trianglesGeom,"color",0,1,0);
+  gprtGeomSet3f(trianglesGeom,"color",1,1,1);
 
   GPRTGeom tetrahedraGeom
     = gprtGeomCreate(context,tetrahedraGeomType);
@@ -202,7 +201,6 @@ int main(int ac, char **av)
                            tetrahedralMesh.NUM_INDICES,sizeof(float3) * 2,0);
   gprtGeomSetBuffer(tetrahedraGeom,"vertex",tetrahedraVertexBuffer);
   gprtGeomSetBuffer(tetrahedraGeom,"index",tetrahedraIndexBuffer);
-  gprtGeomSet3f(tetrahedraGeom,"color",0,1,0);
 
   // ------------------------------------------------------------------
   // the group/accel for that mesh

--- a/samples/int08-multipleTLAS/hostCode.cpp
+++ b/samples/int08-multipleTLAS/hostCode.cpp
@@ -324,7 +324,9 @@ int main(int ac, char **av)
       firstFrame = false;
       float4 position = {lookFrom.x, lookFrom.y, lookFrom.z, 1.f};
       float4 pivot = {lookAt.x, lookAt.y, lookAt.z, 1.0};
+      #ifndef M_PI
       #define M_PI 3.1415926f
+      #endif
 
       // step 1 : Calculate the amount of rotation given the mouse movement.
       float deltaAngleX = (2 * M_PI / fbSize.x);

--- a/samples/int08-multipleTLAS/hostCode.cpp
+++ b/samples/int08-multipleTLAS/hostCode.cpp
@@ -273,8 +273,8 @@ int main(int ac, char **av)
   // ##################################################################
   // build *SBT* required to trace the groups
   // ##################################################################
-  gprtBuildPrograms(context);
-  gprtBuildSBT(context);
+  gprtBuildPipeline(context);
+  gprtBuildShaderBindingTable(context);
 
   // ##################################################################
   // create a window we can use to display and interact with the image
@@ -359,7 +359,7 @@ int main(int ac, char **av)
       gprtRayGenSet3fv    (rayGen,"camera.dir_du",(float*)&camera_ddu);
       gprtRayGenSet3fv    (rayGen,"camera.dir_dv",(float*)&camera_ddv);
 
-      gprtBuildSBT(context);
+      gprtBuildShaderBindingTable(context);
     }
 
     // Now, trace rays


### PR DESCRIPTION
This PR modifies how GPRT constructs its shader binding table.

Previously, multiple instance acceleration structures would cause a crash. 

Now, when we build our SBT, we iterate over all top level acceleration structures, then iterate over all geometry of all bottom level structures in that top level, inserting a hit record for each. 

Instance acceleration structure construction now uses the instance SBT offset in order to allow for multiple instance acceleration structures to reference records in the same SBT.

To demonstrate this, this PR also adds a little demo with one tree containing triangle geometry, and another tree containing user geometry (a volumetric tetrahedron). We use both trees in the same ray generation program.