### PR TITLE
Add ability to profile a gprt launch

### DIFF
--- a/gprt/gprt.cpp
+++ b/gprt/gprt.cpp
@@ -2353,17 +2353,13 @@ struct Context {
       enabledDeviceExtensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     #endif
 
-    VkPhysicalDeviceHostQueryResetFeatures resetFeatures;
-    resetFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES;
-    resetFeatures.pNext = nullptr;
-    resetFeatures.hostQueryReset = VK_TRUE;
 
     VkPhysicalDeviceBufferDeviceAddressFeatures bufferDeviceAddressFeatures = {};
     bufferDeviceAddressFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES;
     bufferDeviceAddressFeatures.bufferDeviceAddress = VK_TRUE;
     bufferDeviceAddressFeatures.bufferDeviceAddressCaptureReplay = VK_FALSE;
     bufferDeviceAddressFeatures.bufferDeviceAddressMultiDevice = VK_FALSE;
-    bufferDeviceAddressFeatures.pNext = &resetFeatures;
+    bufferDeviceAddressFeatures.pNext = nullptr;
 
     VkPhysicalDeviceAccelerationStructureFeaturesKHR accelerationStructureFeatures{};
     accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;

--- a/gprt/gprt.cpp
+++ b/gprt/gprt.cpp
@@ -1867,6 +1867,9 @@ struct Context {
   VkCommandPool graphicsCommandPool;
   VkCommandPool computeCommandPool;
   VkCommandPool transferCommandPool;
+  VkQueryPool queryPool;
+  bool queryRequested = false;
+
   /** @brief Pipeline stages used to wait at for graphics queue submissions */
   VkPipelineStageFlags submitPipelineStages = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT; // not sure I need this one
   // Contains command buffers and semaphores to be presented to the queue
@@ -2107,8 +2110,6 @@ struct Context {
     // If requested, we enable the default validation layers for debugging
     if (validation())
     {
-
-
       gprt::vkCreateDebugUtilsMessengerEXT = reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(vkGetInstanceProcAddr(instance, "vkCreateDebugUtilsMessengerEXT"));
       gprt::vkDestroyDebugUtilsMessengerEXT = reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(vkGetInstanceProcAddr(instance, "vkDestroyDebugUtilsMessengerEXT"));
 
@@ -2352,11 +2353,17 @@ struct Context {
       enabledDeviceExtensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     #endif
 
+    VkPhysicalDeviceHostQueryResetFeatures resetFeatures;
+    resetFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES;
+    resetFeatures.pNext = nullptr;
+    resetFeatures.hostQueryReset = VK_TRUE;
+
     VkPhysicalDeviceBufferDeviceAddressFeatures bufferDeviceAddressFeatures = {};
     bufferDeviceAddressFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES;
     bufferDeviceAddressFeatures.bufferDeviceAddress = VK_TRUE;
     bufferDeviceAddressFeatures.bufferDeviceAddressCaptureReplay = VK_FALSE;
     bufferDeviceAddressFeatures.bufferDeviceAddressMultiDevice = VK_FALSE;
+    bufferDeviceAddressFeatures.pNext = &resetFeatures;
 
     VkPhysicalDeviceAccelerationStructureFeaturesKHR accelerationStructureFeatures{};
     accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
@@ -2459,6 +2466,18 @@ struct Context {
     computeCommandPool = createCommandPool(queueFamilyIndices.compute);
     transferCommandPool = createCommandPool(queueFamilyIndices.transfer);
 
+    /// 4.5 Create a query pool to measure performance
+    VkQueryPoolCreateInfo queryPoolCreateInfo{};
+    queryPoolCreateInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+    queryPoolCreateInfo.pNext = nullptr; // Optional
+    queryPoolCreateInfo.flags = 0; // Reserved for future use, must be 0!
+
+    queryPoolCreateInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
+    queryPoolCreateInfo.queryCount = 2; // for now, just two queries, a before and an after.
+
+    err = vkCreateQueryPool(logicalDevice, &queryPoolCreateInfo, nullptr, &queryPool);
+    if (err) throw std::runtime_error("Failed to create time query pool!");
+
     /// 5. Allocate command buffers
     VkCommandBufferAllocateInfo cmdBufAllocateInfo{};
     cmdBufAllocateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
@@ -2507,6 +2526,7 @@ struct Context {
     vkDestroyCommandPool(logicalDevice, graphicsCommandPool, nullptr);
     vkDestroyCommandPool(logicalDevice, computeCommandPool, nullptr);
     vkDestroyCommandPool(logicalDevice, transferCommandPool, nullptr);
+    vkDestroyQueryPool(logicalDevice, queryPool, nullptr);
     vkDestroyDevice(logicalDevice, nullptr);
 
     freeDebugCallback(instance);
@@ -3574,6 +3594,11 @@ gprtRayGenLaunch3D(GPRTContext _context, GPRTRayGen _rayGen, int dims_x, int dim
 
   err = vkBeginCommandBuffer(context->graphicsCommandBuffer, &cmdBufInfo);
 
+  if (context->queryRequested) {
+    vkCmdResetQueryPool(context->graphicsCommandBuffer,  context->queryPool, 0, 2);
+    vkCmdWriteTimestamp(context->graphicsCommandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, context->queryPool, 0);
+  }
+
   vkCmdBindPipeline(
     context->graphicsCommandBuffer,
     VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR,
@@ -3658,6 +3683,9 @@ gprtRayGenLaunch3D(GPRTContext _context, GPRTRayGen _rayGen, int dims_x, int dim
     dims_x,
     dims_y,
     dims_z);
+  
+  if (context->queryRequested)
+    vkCmdWriteTimestamp(context->graphicsCommandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, context->queryPool, 1);
 
   err = vkEndCommandBuffer(context->graphicsCommandBuffer);
   if (err) GPRT_RAISE("failed to end command buffer! : \n" + errorString(err));
@@ -3709,6 +3737,11 @@ gprtComputeLaunch3D(GPRTContext _context, GPRTCompute _compute, int dims_x, int 
 
   err = vkBeginCommandBuffer(context->graphicsCommandBuffer, &cmdBufInfo);
 
+  if (context->queryRequested) {
+    vkCmdResetQueryPool(context->graphicsCommandBuffer,  context->queryPool, 0, 2);
+    vkCmdWriteTimestamp(context->graphicsCommandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, context->queryPool, 0);
+  }
+  
   vkCmdBindPipeline(
     context->graphicsCommandBuffer,
     VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR,
@@ -3777,6 +3810,9 @@ gprtComputeLaunch3D(GPRTContext _context, GPRTCompute _compute, int dims_x, int 
     dims_y,
     dims_z);
 
+  if (context->queryRequested)
+    vkCmdWriteTimestamp(context->graphicsCommandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, context->queryPool, 1);
+
   err = vkEndCommandBuffer(context->graphicsCommandBuffer);
   if (err) GPRT_RAISE("failed to end command buffer! : \n" + errorString(err));
 
@@ -3796,6 +3832,31 @@ gprtComputeLaunch3D(GPRTContext _context, GPRTCompute _compute, int dims_x, int 
 
   err = vkQueueWaitIdle(context->graphicsQueue);
   if (err) GPRT_RAISE("failed to wait for queue idle! : \n" + errorString(err));
+}
+
+GPRT_API void gprtBeginProfile(GPRTContext _context)
+{
+  LOG_API_CALL();
+  assert(_context);
+  Context *context = (Context*)_context;
+  context->queryRequested = true;  
+}
+
+GPRT_API float gprtEndProfile(GPRTContext _context)
+{
+  LOG_API_CALL();
+  assert(_context);
+  Context *context = (Context*)_context;
+
+  if (context->queryRequested != true) GPRT_RAISE("Requested profile data without calling gprtBeginProfile");
+  context->queryRequested = false;  
+
+  uint64_t buffer[2];
+  VkResult result = vkGetQueryPoolResults(context->logicalDevice, context->queryPool, 0, 2, sizeof(uint64_t) * 2, buffer, sizeof(uint64_t), VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
+  if (result != VK_SUCCESS) throw std::runtime_error("Failed to receive query results!");
+  uint64_t timeResults = buffer[1] - buffer[0];
+  float time = float(timeResults) / context->deviceProperties.limits.timestampPeriod;
+  return time;
 }
 
 std::pair<size_t, void*> gprtGetVariable(

--- a/gprt/gprt_host.h
+++ b/gprt/gprt_host.h
@@ -754,6 +754,10 @@ gprtComputeLaunch2D(GPRTContext context, GPRTCompute compute, int dims_x, int di
 GPRT_API void
 gprtComputeLaunch3D(GPRTContext context, GPRTCompute compute, int dims_x, int dims_y, int dims_z);
 
+GPRT_API void gprtBeginProfile(GPRTContext context);
+
+// returned results are in nanoseconds
+GPRT_API float gprtEndProfile(GPRTContext context);
 #ifdef __cplusplus
 // ------------------------------------------------------------------
 // setters for variables of type "bool" (bools only on c++)

--- a/samples/int07-doublePrecision/hostCode.cpp
+++ b/samples/int07-doublePrecision/hostCode.cpp
@@ -300,7 +300,7 @@ int main(int ac, char **av)
     gprtBeginProfile(context);
     gprtRayGenLaunch2D(context,rayGen,fbSize.x,fbSize.y);
     float ms = gprtEndProfile(context) * 0.000001;
-    std::cout<<"time " << ms << "ms" << std::endl;
+    std::cout<<"time " << ms << " ms" << std::endl;
 
     // Render results to screen
     void* pixels = gprtBufferGetPointer(frameBuffer);

--- a/samples/int07-doublePrecision/hostCode.cpp
+++ b/samples/int07-doublePrecision/hostCode.cpp
@@ -297,7 +297,10 @@ int main(int ac, char **av)
     }
 
     // Now, trace rays
+    gprtBeginProfile(context);
     gprtRayGenLaunch2D(context,rayGen,fbSize.x,fbSize.y);
+    float ms = gprtEndProfile(context) * 0.000001;
+    std::cout<<"time " << ms << "ms" << std::endl;
 
     // Render results to screen
     void* pixels = gprtBufferGetPointer(frameBuffer);
@@ -347,6 +350,7 @@ int main(int ac, char **av)
     
     glfwSwapBuffers(window);
     glfwPollEvents();
+    
   }
 
   // ##################################################################


### PR DESCRIPTION
This PR adds the ability to profile how long it takes to execute a GPRT launch.

To do so, we introduce two new API, gprtBeginProfile and gprtEndProfile, the latter returning the time taken to execute in nanoseconds. These must be added before and after a call to either gprtRayGenLaunchND or gprtComputeLaunchND.

Under the hood, we now allocate a vulkan query pool, allocating two timestamp queries. 

Down the road, gprtRayGenLaunch2D may become asynchronous. If that is the case, gprtEndProfile currently will force the GPU to synchronize in order to return the results. We can change this behavior if necessary to have gprtEndProfile report a "not ready" result until the asynchronous launch is complete, but for now this should suffice. 