### PR TITLE
SBT Index Correction, Updates to instance transform API and updated find dxc hints

### DIFF
--- a/gprt/cmake/embed_devicecode.cmake
+++ b/gprt/cmake/embed_devicecode.cmake
@@ -24,7 +24,7 @@ cmake_minimum_required(VERSION 3.12)
 
 find_program(CMAKE_DXC_COMPILER dxc
   DOC "Path to the dxc executable."
-  HINTS ${Vulkan_BIN_DIR} ${DXC_BIN_DIR}
+  HINTS ${Vulkan_INCLUDE_DIR}/../Bin/ ${DXC_BIN_DIR}
 )
 
 # set(CMAKE_SPIRV_OPTIMIZER ${Vulkan_BIN_DIR}/spirv-opt)

--- a/gprt/gprt.cpp
+++ b/gprt/gprt.cpp
@@ -531,7 +531,7 @@ struct Buffer {
         return 0;
       }
       else {
-        throw std::runtime_error("Could not find a matching memory type");
+        GPRT_RAISE("Could not find a matching memory type");
       }
     };
 
@@ -578,7 +578,7 @@ struct Buffer {
 
     // Attach the memory to the buffer object
     VkResult err = vkBindBufferMemory(device, buffer, memory, /* offset */ 0);
-    if (err) throw std::runtime_error("failed to bind buffer memory! : \n" + errorString(err));
+    if (err) GPRT_RAISE("failed to bind buffer memory! : \n" + errorString(err));
 
     if (!hostVisible) {
       const VkMemoryPropertyFlags memoryPropertyFlags =
@@ -606,7 +606,7 @@ struct Buffer {
 
       // Attach the memory to the buffer object
       VkResult err = vkBindBufferMemory(device, stagingBuffer.buffer, stagingBuffer.memory, /* offset */ 0);
-      if (err) throw std::runtime_error("failed to bind staging buffer memory! : \n" + errorString(err));
+      if (err) GPRT_RAISE("failed to bind staging buffer memory! : \n" + errorString(err));
     }
 
     // If a pointer to the buffer data has been passed, map the buffer and
@@ -707,7 +707,7 @@ struct RayGen : public SBTEntry {
 
     VkResult err = vkCreateShaderModule(logicalDevice, &moduleCreateInfo,
       NULL, &shaderModule);
-    if (err) throw std::runtime_error("failed to create shader module! : \n" + errorString(err));
+    if (err) GPRT_RAISE("failed to create shader module! : \n" + errorString(err));
 
     shaderStage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStage.stage = VK_SHADER_STAGE_RAYGEN_BIT_KHR;
@@ -1549,7 +1549,7 @@ struct InstanceAccel : public Accel {
           numGeometry += aabbAccel->geometries.size();
         }
         else {
-          throw std::runtime_error("Unaccounted for BLAS type!");
+          GPRT_RAISE("Unaccounted for BLAS type!");
         }
       }
       this->numGeometries = numGeometry;
@@ -1580,7 +1580,7 @@ struct InstanceAccel : public Accel {
     ) 
   {
     if (count != this->numInstances) {
-      throw std::runtime_error("Error, transform count must match number of instances!");
+      GPRT_RAISE("Error, transform count must match number of instances!");
     }
     // assuming no motion blurred triangles for now, so we assume 1 transform per instance
     this->transforms.buffer = transforms;
@@ -1617,7 +1617,7 @@ struct InstanceAccel : public Accel {
 
   size_t getNumGeometries() {
     if (this->numGeometries == -1) {
-      throw std::runtime_error("Error, numGeometries for this instance must be set by the user!");
+      GPRT_RAISE("Error, numGeometries for this instance must be set by the user!");
     }
     return this->numGeometries;
   }
@@ -1724,7 +1724,7 @@ struct InstanceAccel : public Accel {
           AABBAccel* aabbAccel = (AABBAccel*)this->instances[i];
           offset += aabbAccel->geometries.size() * numRayTypes;
         } else {
-          throw std::runtime_error("Error, unknown instance type");
+          GPRT_RAISE("Error, unknown instance type");
         }
       }
       instanceOffsetsBuffer->map();
@@ -2268,7 +2268,7 @@ struct Context {
 
     err = vkCreateInstance(&instanceCreateInfo, nullptr, &instance);
     if (err) {
-      throw std::runtime_error("failed to create instance! : \n" + errorString(err));
+      GPRT_RAISE("failed to create instance! : \n" + errorString(err));
     }
 
     // err = createDebugUtilsMessenger(instance,
@@ -2278,7 +2278,7 @@ struct Context {
     //     &instance.debug_messenger,
     //     info.allocation_callbacks);
     // if (err) {
-    //   throw std::runtime_error("failed to debug messenger callback! : \n" + errorString(err));
+    //   GPRT_RAISE("failed to debug messenger callback! : \n" + errorString(err));
     // }
 
     /// 2. Select a Physical Device
@@ -2306,13 +2306,13 @@ struct Context {
     // Get number of available physical devices
     VK_CHECK_RESULT(vkEnumeratePhysicalDevices(instance, &gpuCount, nullptr));
     if (gpuCount == 0) {
-      throw std::runtime_error("No device with Vulkan support found : \n" + errorString(err));
+      GPRT_RAISE("No device with Vulkan support found : \n" + errorString(err));
     }
     // Enumerate devices
     std::vector<VkPhysicalDevice> physicalDevices(gpuCount);
     err = vkEnumeratePhysicalDevices(instance, &gpuCount, physicalDevices.data());
     if (err) {
-      throw std::runtime_error("Could not enumerate physical devices : \n" + errorString(err));
+      GPRT_RAISE("Could not enumerate physical devices : \n" + errorString(err));
     }
 
     // GPU selection
@@ -2437,7 +2437,7 @@ struct Context {
         for (uint32_t i = 0; i < static_cast<uint32_t>(queueFamilyProperties.size()); i++)
           if (queueFamilyProperties[i].queueFlags & queueFlags)
             return i;
-        throw std::runtime_error("Could not find a matching queue family index");
+        GPRT_RAISE("Could not find a matching queue family index");
       };
 
     const float defaultQueuePriority(0.0f);
@@ -2605,7 +2605,7 @@ struct Context {
     // this->enabledFeatures = enabledFeatures;
     err = vkCreateDevice(physicalDevice, &deviceCreateInfo, nullptr, &logicalDevice);
     if (err) {
-      throw std::runtime_error("Could not create logical devices : \n" + errorString(err));
+      GPRT_RAISE("Could not create logical devices : \n" + errorString(err));
     }
 
     // Get the ray tracing and acceleration structure related function pointers required by this sample
@@ -2649,7 +2649,7 @@ struct Context {
     queryPoolCreateInfo.queryCount = 2; // for now, just two queries, a before and an after.
 
     err = vkCreateQueryPool(logicalDevice, &queryPoolCreateInfo, nullptr, &queryPool);
-    if (err) throw std::runtime_error("Failed to create time query pool!");
+    if (err) GPRT_RAISE("Failed to create time query pool!");
 
     /// 5. Allocate command buffers
     VkCommandBufferAllocateInfo cmdBufAllocateInfo{};
@@ -2659,15 +2659,15 @@ struct Context {
 
     cmdBufAllocateInfo.commandPool = graphicsCommandPool;
     err = vkAllocateCommandBuffers(logicalDevice, &cmdBufAllocateInfo, &graphicsCommandBuffer);
-    if (err) throw std::runtime_error("Could not create graphics command buffer : \n" + errorString(err));
+    if (err) GPRT_RAISE("Could not create graphics command buffer : \n" + errorString(err));
 
     cmdBufAllocateInfo.commandPool = computeCommandPool;
     err = vkAllocateCommandBuffers(logicalDevice, &cmdBufAllocateInfo, &computeCommandBuffer);
-    if (err) throw std::runtime_error("Could not create compute command buffer : \n" + errorString(err));
+    if (err) GPRT_RAISE("Could not create compute command buffer : \n" + errorString(err));
 
     cmdBufAllocateInfo.commandPool = transferCommandPool;
     err = vkAllocateCommandBuffers(logicalDevice, &cmdBufAllocateInfo, &transferCommandBuffer);
-    if (err) throw std::runtime_error("Could not create transfer command buffer : \n" + errorString(err));
+    if (err) GPRT_RAISE("Could not create transfer command buffer : \n" + errorString(err));
 
     /// 6. Get queue handles
     vkGetDeviceQueue(logicalDevice, queueFamilyIndices.graphics, 0, &graphicsQueue);
@@ -2730,7 +2730,7 @@ struct Context {
 
     std::vector<uint8_t> shaderHandleStorage(sbtSize);
     VkResult err = gprt::vkGetRayTracingShaderGroupHandles(logicalDevice, pipeline, 0, groupCount, sbtSize, shaderHandleStorage.data());
-    if (err) throw std::runtime_error("failed to get ray tracing shader group handles! : \n" + errorString(err));
+    if (err) GPRT_RAISE("failed to get ray tracing shader group handles! : \n" + errorString(err));
 
     const VkBufferUsageFlags bufferUsageFlags = 
       // means we can use this buffer as a SBT
@@ -2907,7 +2907,7 @@ struct Context {
             }
             
             else {
-              throw std::runtime_error("Unaccounted for BLAS type!");
+              GPRT_RAISE("Unaccounted for BLAS type!");
             }
           }
         }
@@ -3087,7 +3087,7 @@ struct Context {
             }
           }
           else {
-            throw std::runtime_error("Unaccounted for BLAS type!");
+            GPRT_RAISE("Unaccounted for BLAS type!");
           }
         }
       }
@@ -3114,7 +3114,7 @@ struct Context {
       nullptr, &pipeline
     );
     if (err) {
-      throw std::runtime_error("failed to create ray tracing pipeline! : \n" + errorString(err));
+      GPRT_RAISE("failed to create ray tracing pipeline! : \n" + errorString(err));
     }
   }
 
@@ -4067,7 +4067,7 @@ GPRT_API float gprtEndProfile(GPRTContext _context)
 
   uint64_t buffer[2];
   VkResult result = vkGetQueryPoolResults(context->logicalDevice, context->queryPool, 0, 2, sizeof(uint64_t) * 2, buffer, sizeof(uint64_t), VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
-  if (result != VK_SUCCESS) throw std::runtime_error("Failed to receive query results!");
+  if (result != VK_SUCCESS) GPRT_RAISE("Failed to receive query results!");
   uint64_t timeResults = buffer[1] - buffer[0];
   float time = float(timeResults) / context->deviceProperties.limits.timestampPeriod;
   return time;

--- a/gprt/gprt.cpp
+++ b/gprt/gprt.cpp
@@ -1151,46 +1151,63 @@ struct TriangleAccel : public Accel {
       &accelerationStructureBuildSizesInfo
     );
     
-    accelBuffer = new Buffer(
-      physicalDevice, logicalDevice, VK_NULL_HANDLE, VK_NULL_HANDLE, 
-      // means we can use this buffer as a means of storing an acceleration structure
-      VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | 
-      // means we can get this buffer's address with vkGetBufferDeviceAddress
-      VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, 
-      // means that this memory is stored directly on the device 
-      //  (rather than the host, or in a special host/device section)
-      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-      accelerationStructureBuildSizesInfo.accelerationStructureSize
-    );
+    if (accelBuffer && accelBuffer->size != accelerationStructureBuildSizesInfo.accelerationStructureSize)
+    {
+      // Destroy old accel handle too
+      gprt::vkDestroyAccelerationStructure(logicalDevice, accelerationStructure, nullptr);
+      accelerationStructure = VK_NULL_HANDLE;
+      accelBuffer->destroy();
+      delete(accelBuffer);
+      accelBuffer = nullptr;
+    }
 
-    scratchBuffer = new Buffer(
-      physicalDevice, logicalDevice, VK_NULL_HANDLE, VK_NULL_HANDLE, 
-      // means that the buffer can be used in a VkDescriptorBufferInfo. // Is this required? If not, remove this...
-      VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | 
-      // means we can get this buffer's address with vkGetBufferDeviceAddress
-      VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, 
-      // means that this memory is stored directly on the device 
-      //  (rather than the host, or in a special host/device section)
-      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-      accelerationStructureBuildSizesInfo.buildScratchSize
-    );
+    if (!accelBuffer) {
+      accelBuffer = new Buffer(
+        physicalDevice, logicalDevice, VK_NULL_HANDLE, VK_NULL_HANDLE, 
+        // means we can use this buffer as a means of storing an acceleration structure
+        VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | 
+        // means we can get this buffer's address with vkGetBufferDeviceAddress
+        VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, 
+        // means that this memory is stored directly on the device 
+        //  (rather than the host, or in a special host/device section)
+        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+        accelerationStructureBuildSizesInfo.accelerationStructureSize
+      );
 
-    VkAccelerationStructureCreateInfoKHR accelerationStructureCreateInfo{};
-    accelerationStructureCreateInfo.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR;
-    accelerationStructureCreateInfo.buffer = accelBuffer->buffer;
-    accelerationStructureCreateInfo.size = accelerationStructureBuildSizesInfo.accelerationStructureSize;
-    accelerationStructureCreateInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
-    err = gprt::vkCreateAccelerationStructure(
-      logicalDevice,
-      &accelerationStructureCreateInfo, 
-      nullptr,
-      &accelerationStructure
-    );
-    if (err) GPRT_RAISE("failed to create acceleration structure for triangle accel build! : \n" + errorString(err));
+      VkAccelerationStructureCreateInfoKHR accelerationStructureCreateInfo{};
+      accelerationStructureCreateInfo.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR;
+      accelerationStructureCreateInfo.buffer = accelBuffer->buffer;
+      accelerationStructureCreateInfo.size = accelerationStructureBuildSizesInfo.accelerationStructureSize;
+      accelerationStructureCreateInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
+      err = gprt::vkCreateAccelerationStructure(
+        logicalDevice,
+        &accelerationStructureCreateInfo, 
+        nullptr,
+        &accelerationStructure
+      );
+      if (err) GPRT_RAISE("failed to create acceleration structure for triangle accel build! : \n" + errorString(err));
+    }
 
+    if (scratchBuffer && scratchBuffer->size != accelerationStructureBuildSizesInfo.buildScratchSize)
+    {
+      scratchBuffer->destroy();
+      delete(scratchBuffer);
+      scratchBuffer = nullptr;
+    }
 
-
-
+    if (!scratchBuffer) {
+      scratchBuffer = new Buffer(
+        physicalDevice, logicalDevice, VK_NULL_HANDLE, VK_NULL_HANDLE, 
+        // means that the buffer can be used in a VkDescriptorBufferInfo. // Is this required? If not, remove this...
+        VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | 
+        // means we can get this buffer's address with vkGetBufferDeviceAddress
+        VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, 
+        // means that this memory is stored directly on the device 
+        //  (rather than the host, or in a special host/device section)
+        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+        accelerationStructureBuildSizesInfo.buildScratchSize
+      );
+    }
 
     VkAccelerationStructureBuildGeometryInfoKHR accelerationBuildGeometryInfo{};
     accelerationBuildGeometryInfo.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
@@ -1478,40 +1495,65 @@ struct AABBAccel : public Accel {
 };
 
 struct InstanceAccel : public Accel {
+  size_t numInstances;
   std::vector<Accel*> instances; 
+
+  // the total number of geometries referenced by this instance accel's BLASes
+  size_t numGeometries = -1;
 
   size_t instanceOffset = -1;
 
   Buffer *instancesBuffer = nullptr;
   Buffer *accelAddressesBuffer = nullptr;
+  Buffer *instanceOffsetsBuffer = nullptr;
+
+  struct {
+    Buffer* buffer = nullptr;
+    size_t stride = 0;
+    size_t offset = 0;
+  } transforms;
 
   struct {
     Buffer* buffer = nullptr;
     // size_t stride = 0;
     // size_t offset = 0;
-  } transforms;
-  
+  } references;
+
+  struct {
+    Buffer* buffer = nullptr;
+    // size_t stride = 0;
+    // size_t offset = 0;
+  } offsets;
+
   // todo, accept this in constructor
   VkBuildAccelerationStructureFlagsKHR flags = VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR;
 
   InstanceAccel(VkPhysicalDevice physicalDevice, VkDevice logicalDevice, VkCommandBuffer commandBuffer, VkQueue queue,
     size_t numInstances, GPRTAccel* instances) : Accel(physicalDevice, logicalDevice, commandBuffer, queue) 
   {
-    this->instances.resize(numInstances);
-    memcpy(this->instances.data(), instances, sizeof(GPRTAccel*) * numInstances);
+    this->numInstances = numInstances;
 
-    accelAddressesBuffer = new Buffer(
-      physicalDevice, logicalDevice, commandBuffer, queue,
-      // I guess I need this to use these buffers as input to tree builds?
-      VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | 
-      // means we can get this buffer's address with vkGetBufferDeviceAddress
-      VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, 
-      // means that this memory is stored directly on the device 
-      //  (rather than the host, or in a special host/device section)
-      // VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | // temporary (doesn't work on AMD)
-      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, // temporary
-      sizeof(uint64_t) * numInstances
-    );
+    if (instances) {
+      this->instances.resize(numInstances);
+      memcpy(this->instances.data(), instances, sizeof(GPRTAccel*) * numInstances);
+
+      // count number of geometry referenced.
+      size_t numGeometry = 0;
+      for (uint32_t j = 0; j < this->instances.size(); ++j) {
+        if (this->instances[j]->getType() == GPRT_TRIANGLE_ACCEL) {
+          TriangleAccel *triangleAccel = (TriangleAccel*) this->instances[j];
+          numGeometry += triangleAccel->geometries.size();
+        }
+        else if (this->instances[j]->getType() == GPRT_AABB_ACCEL) {
+          AABBAccel *aabbAccel = (AABBAccel*) this->instances[j];
+          numGeometry += aabbAccel->geometries.size();
+        }
+        else {
+          throw std::runtime_error("Unaccounted for BLAS type!");
+        }
+      }
+      this->numGeometries = numGeometry;
+    }
 
     instancesBuffer = new Buffer(
       physicalDevice, logicalDevice, commandBuffer, queue,
@@ -1524,21 +1566,60 @@ struct InstanceAccel : public Accel {
       // VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
       // VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, // temporary
       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-      sizeof(VkAccelerationStructureInstanceKHR) * this->instances.size()
+      sizeof(VkAccelerationStructureInstanceKHR) * numInstances
     );
   };
   
   ~InstanceAccel() {};
 
   void setTransforms(
-    Buffer* transforms//,
+    Buffer* transforms,
+    size_t count,
+    size_t stride,
+    size_t offset
+    ) 
+  {
+    if (count != this->numInstances) {
+      throw std::runtime_error("Error, transform count must match number of instances!");
+    }
+    // assuming no motion blurred triangles for now, so we assume 1 transform per instance
+    this->transforms.buffer = transforms;
+    this->transforms.stride = stride;
+    this->transforms.offset = offset;
+  }
+
+  void setReferences(
+    Buffer* references = nullptr//,
     // size_t count,
     // size_t stride,
     // size_t offset
     ) 
   {
-    // assuming no motion blurred triangles for now, so we assume 1 transform per instance
-    this->transforms.buffer = transforms;
+    this->references.buffer = references;
+  }
+
+  void setOffsets(
+    Buffer* offsets = nullptr//,
+    // size_t count,
+    // size_t stride,
+    // size_t offset
+    ) 
+  {
+    this->offsets.buffer = offsets;
+  }
+
+  void setNumGeometries(
+    size_t numGeometries
+  )
+  {
+    this->numGeometries = numGeometries;
+  }
+
+  size_t getNumGeometries() {
+    if (this->numGeometries == -1) {
+      throw std::runtime_error("Error, numGeometries for this instance must be set by the user!");
+    }
+    return this->numGeometries;
   }
 
   AccelType getType() {return GPRT_INSTANCE_ACCEL;}
@@ -1546,40 +1627,123 @@ struct InstanceAccel : public Accel {
   void build(std::map<std::string, Stage> internalStages, std::vector<Accel*> accels, uint32_t numRayTypes) {
     VkResult err;
 
-    std::vector<uint64_t> addresses(instances.size());
-    for (uint32_t i = 0; i < instances.size(); ++i) 
-      addresses[i] = this->instances[i]->address;
-    accelAddressesBuffer->map();
-    memcpy(accelAddressesBuffer->mapped, addresses.data(), sizeof(uint64_t) * instances.size());
-
-    // The instance shader binding table record offset is the total number 
-    // of geometries referenced by all instances up until this instance tree
-    // multiplied by the number of ray types.
+    // Compute the instance offset for the SBT record. 
+    //   The instance shader binding table record offset is the total number 
+    //   of geometries referenced by all instances up until this instance tree
+    //   multiplied by the number of ray types.
     uint64_t instanceShaderBindingTableRecordOffset = 0;
     for (uint32_t i = 0; i < accels.size(); ++i) {
       if (accels[i] == this) break;
       if (accels[i]->getType() == GPRT_INSTANCE_ACCEL) {
         InstanceAccel *instanceAccel = (InstanceAccel*) accels[i];
-
-        uint64_t numGeometry = 0;
-        for (uint32_t j = 0; j < instanceAccel->instances.size(); ++j) {
-          if (instanceAccel->instances[j]->getType() == GPRT_TRIANGLE_ACCEL) {
-            TriangleAccel *triangleAccel = (TriangleAccel*) instanceAccel->instances[j];
-            numGeometry += triangleAccel->geometries.size();
-          }
-          else if (instanceAccel->instances[j]->getType() == GPRT_AABB_ACCEL) {
-            AABBAccel *aabbAccel = (AABBAccel*) instanceAccel->instances[j];
-            numGeometry += aabbAccel->geometries.size();
-          }
-          else {
-            throw std::runtime_error("Unaccounted for tree type in instance SBT offset!");
-          }
-        }
+        size_t numGeometry = instanceAccel->getNumGeometries();
         instanceShaderBindingTableRecordOffset += numGeometry * numRayTypes;
       }
     }
-
     instanceOffset = instanceShaderBindingTableRecordOffset;
+    
+    // No instance addressed provided, so we need to supply our own.
+    uint64_t referencesAddress;
+    if (references.buffer == nullptr) {
+      // delete if not big enough
+      if (accelAddressesBuffer && accelAddressesBuffer->size != numInstances * sizeof(uint64_t))
+      {
+        accelAddressesBuffer->destroy();
+        delete accelAddressesBuffer;
+        accelAddressesBuffer = nullptr;
+      }
+      
+      // make buffer if not made yet
+      if (accelAddressesBuffer == nullptr) {
+        accelAddressesBuffer = new Buffer(
+          physicalDevice, logicalDevice, commandBuffer, queue,
+          // I guess I need this to use these buffers as input to tree builds?
+          VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | 
+          // means we can get this buffer's address with vkGetBufferDeviceAddress
+          VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, 
+          // means that this memory is stored directly on the device 
+          //  (rather than the host, or in a special host/device section)
+          // VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | // temporary (doesn't work on AMD)
+          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, // temporary
+          sizeof(uint64_t) * numInstances
+        );
+      }
+
+      // transfer over addresses
+      std::vector<uint64_t> addresses(numInstances);
+      for (uint32_t i = 0; i < numInstances; ++i) 
+        addresses[i] = this->instances[i]->address;
+      accelAddressesBuffer->map();
+      memcpy(accelAddressesBuffer->mapped, addresses.data(), sizeof(uint64_t) * numInstances);
+      accelAddressesBuffer->unmap();
+      referencesAddress = accelAddressesBuffer->address;
+    }
+    // Instance acceleration structure references provided by the user
+    else {
+      referencesAddress = references.buffer->address;
+    }
+
+    // No instance offsets provided, so we need to supply our own.
+    uint64_t instanceOffsetsAddress;
+    if (offsets.buffer == nullptr) {
+      // delete if not big enough
+      if (instanceOffsetsBuffer && instanceOffsetsBuffer->size != numInstances * sizeof(uint64_t))
+      {
+        instanceOffsetsBuffer->destroy();
+        delete instanceOffsetsBuffer;
+        instanceOffsetsBuffer = nullptr;
+      }
+      
+      // make buffer if not made yet
+      if (instanceOffsetsBuffer == nullptr) {
+        instanceOffsetsBuffer = new Buffer(
+          physicalDevice, logicalDevice, commandBuffer, queue,
+          // I guess I need this to use these buffers as input to tree builds?
+          VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | 
+          // means we can get this buffer's address with vkGetBufferDeviceAddress
+          VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, 
+          // means that this memory is stored directly on the device 
+          //  (rather than the host, or in a special host/device section)
+          // VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | // temporary (doesn't work on AMD)
+          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, // temporary
+          sizeof(uint64_t) * numInstances
+        );
+      }
+
+      // transfer over offsets
+      std::vector<int32_t> blasOffsets(numInstances);
+      int offset = 0;
+      for (uint32_t i = 0; i < numInstances; ++i) {
+        blasOffsets[i] = offset;
+
+        if (this->instances[i]->getType() == GPRT_TRIANGLE_ACCEL) 
+        {
+          TriangleAccel* triAccel = (TriangleAccel*)this->instances[i];
+          offset += triAccel->geometries.size() * numRayTypes;
+        } else if (this->instances[i]->getType() == GPRT_AABB_ACCEL) {
+          AABBAccel* aabbAccel = (AABBAccel*)this->instances[i];
+          offset += aabbAccel->geometries.size() * numRayTypes;
+        } else {
+          throw std::runtime_error("Error, unknown instance type");
+        }
+      }
+      instanceOffsetsBuffer->map();
+      memcpy(instanceOffsetsBuffer->mapped, blasOffsets.data(), sizeof(int32_t) * numInstances);
+      instanceOffsetsBuffer->unmap();
+      instanceOffsetsAddress = instanceOffsetsBuffer->address;
+    }
+    // Instance acceleration structure references provided by the user
+    else {
+      instanceOffsetsAddress = offsets.buffer->address;
+    }
+
+    // No instance addressed provided, so we assume identity.
+    uint64_t transformBufferAddress;
+    if (transforms.buffer == nullptr) {
+      transformBufferAddress = -1;
+    } else {
+      transformBufferAddress = transforms.buffer->address;
+    }
 
     // Use a compute shader to copy transforms into instances buffer
     VkCommandBufferBeginInfo cmdBufInfo{};
@@ -1588,13 +1752,19 @@ struct InstanceAccel : public Accel {
       uint64_t transformBufferAddr;
       uint64_t accelReferencesAddr;
       uint64_t instanceShaderBindingTableRecordOffset;
-      uint64_t pad[16-4];
+      uint64_t transformOffset;
+      uint64_t transformStride;
+      uint64_t instanceOffsetsBufferAddr;
+      uint64_t pad[16-7];
     } pushConstants;
 
     pushConstants.instanceBufferAddr = instancesBuffer->address;
-    pushConstants.transformBufferAddr = transforms.buffer->address;
-    pushConstants.accelReferencesAddr = accelAddressesBuffer->address;
+    pushConstants.transformBufferAddr = transformBufferAddress;
+    pushConstants.accelReferencesAddr = referencesAddress;
     pushConstants.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset;
+    pushConstants.transformOffset = transforms.offset;
+    pushConstants.transformStride = transforms.stride;
+    pushConstants.instanceOffsetsBufferAddr = instanceOffsetsAddress;
 
     cmdBufInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
     err = vkBeginCommandBuffer(commandBuffer, &cmdBufInfo);
@@ -1603,7 +1773,7 @@ struct InstanceAccel : public Accel {
     );
     vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, internalStages["gprtFillInstanceData"].pipeline);
     // vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipelineLayout, 0, 1, &descriptorSet, 0, 0);
-    vkCmdDispatch(commandBuffer, instances.size(), 1, 1);
+    vkCmdDispatch(commandBuffer, numInstances, 1, 1);
     err = vkEndCommandBuffer(commandBuffer);
 
     VkSubmitInfo submitInfo;
@@ -1644,7 +1814,7 @@ struct InstanceAccel : public Accel {
     accelerationStructureBuildGeometryInfo.geometryCount = 1;
     accelerationStructureBuildGeometryInfo.pGeometries = &accelerationStructureGeometry;
 
-    uint32_t primitive_count = instances.size();
+    uint32_t primitive_count = numInstances;
 
     VkAccelerationStructureBuildSizesInfoKHR accelerationStructureBuildSizesInfo{};
     accelerationStructureBuildSizesInfo.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;
@@ -1656,8 +1826,7 @@ struct InstanceAccel : public Accel {
       &accelerationStructureBuildSizesInfo);
     
 
-    if (accelBuffer && accelBuffer->size != accelerationStructureBuildSizesInfo.accelerationStructureSize)
-    {
+    if (accelBuffer && accelBuffer->size != accelerationStructureBuildSizesInfo.accelerationStructureSize) {
       // Destroy old accel handle too
       gprt::vkDestroyAccelerationStructure(logicalDevice, accelerationStructure, nullptr);
       accelerationStructure = VK_NULL_HANDLE;
@@ -1725,7 +1894,7 @@ struct InstanceAccel : public Accel {
     accelerationBuildGeometryInfo.scratchData.deviceAddress = scratchBuffer->address;
 
     VkAccelerationStructureBuildRangeInfoKHR accelerationStructureBuildRangeInfo{};
-    accelerationStructureBuildRangeInfo.primitiveCount = instances.size();
+    accelerationStructureBuildRangeInfo.primitiveCount = numInstances;
     accelerationStructureBuildRangeInfo.primitiveOffset = 0;
     accelerationStructureBuildRangeInfo.firstVertex = 0;
     accelerationStructureBuildRangeInfo.transformOffset = 0;
@@ -1806,6 +1975,12 @@ struct InstanceAccel : public Accel {
       accelAddressesBuffer->destroy();
       delete accelAddressesBuffer;
       accelAddressesBuffer = nullptr;
+    }
+
+    if (instanceOffsetsBuffer) {
+      instanceOffsetsBuffer->destroy();
+      delete instanceOffsetsBuffer;
+      instanceOffsetsBuffer = nullptr;
     }
   };
 };
@@ -1962,17 +2137,19 @@ struct Context {
       if (!accel) continue;
       if (accel->getType() == GPRT_INSTANCE_ACCEL) {
         InstanceAccel* tlas = (InstanceAccel*) accel;
-        for (int blasID = 0; blasID < tlas->instances.size(); ++blasID) {
-          Accel *blas = tlas->instances[blasID];
-          if (blas->getType() == GPRT_TRIANGLE_ACCEL) {
-            TriangleAccel *triAccel = (TriangleAccel*) blas;
-            totalGeometries += triAccel->geometries.size();
-          }
-          if (blas->getType() == GPRT_AABB_ACCEL) {
-            AABBAccel *aabbAccel = (AABBAccel*) blas;
-            totalGeometries += aabbAccel->geometries.size();
-          }
-        }
+        totalGeometries += tlas->getNumGeometries();
+        // // this is a problem, because instances here is a nullptr, set on device...
+        // for (int blasID = 0; blasID < tlas->instances.size(); ++blasID) {
+        //   Accel *blas = tlas->instances[blasID];
+        //   if (blas->getType() == GPRT_TRIANGLE_ACCEL) {
+        //     TriangleAccel *triAccel = (TriangleAccel*) blas;
+        //     totalGeometries += triAccel->geometries.size();
+        //   }
+        //   if (blas->getType() == GPRT_AABB_ACCEL) {
+        //     AABBAccel *aabbAccel = (AABBAccel*) blas;
+        //     totalGeometries += aabbAccel->geometries.size();
+        //   }
+        // }
       }
     }
 
@@ -2655,11 +2832,17 @@ struct Context {
     // Hit records
     if (numHitRecords > 0)
     {
-      for (int tlasID = 0; tlasID < accels.size(); ++tlasID) {
+      // Go over all TLAS by order they were created
+      for (int tlasID = 0; tlasID < accels.size(); ++tlasID) { 
         Accel *tlas = accels[tlasID];
         if (!tlas) continue;
         if (tlas->getType() == GPRT_INSTANCE_ACCEL) {
           InstanceAccel *instanceAccel = (InstanceAccel*) tlas;
+          // this is an issue, because if instances can be set on device, we don't
+          // have a list of instances we can iterate through and copy the SBT data...
+          // So, if we have a bunch of instances set by reference on device, 
+          // we need to eventually do something smarter here...
+          size_t geomIDOffset = 0;
           for (int blasID = 0; blasID < instanceAccel->instances.size(); ++blasID) {
             
             Accel *blas = instanceAccel->instances[blasID];
@@ -2674,7 +2857,8 @@ struct Context {
                   size_t handleStride = handleSize;
 
                   // First, copy handle
-                  size_t instanceOffset = instanceAccel->instanceOffset;
+                  // Account for all prior instance's geometries and for prior BLAS's geometry
+                  size_t instanceOffset = instanceAccel->instanceOffset + geomIDOffset;
                   size_t recordOffset = recordStride * (rayType + numRayTypes * geomID + instanceOffset) + recordStride * (numComputes + numRayGens + numMissProgs);
                   size_t handleOffset = handleStride * (rayType + numRayTypes * geomID + instanceOffset) + handleStride * (numComputes + numRayGens + numMissProgs);
                   memcpy(mapped + recordOffset, shaderHandleStorage.data() + handleOffset, handleSize);
@@ -2689,6 +2873,7 @@ struct Context {
                   }
                 }
               }
+              geomIDOffset += triAccel->geometries.size();
             }
 
             else if (blas->getType() == GPRT_AABB_ACCEL) {
@@ -2702,7 +2887,8 @@ struct Context {
                   size_t handleStride = handleSize;
 
                   // First, copy handle
-                  size_t instanceOffset = instanceAccel->instanceOffset;
+                  // Account for all prior instance's geometries and for prior BLAS's geometry
+                  size_t instanceOffset = instanceAccel->instanceOffset + geomIDOffset;
                   size_t recordOffset = recordStride * (rayType + numRayTypes * geomID + instanceOffset) + recordStride * (numComputes + numRayGens + numMissProgs);
                   size_t handleOffset = handleStride * (rayType + numRayTypes * geomID + instanceOffset) + handleStride * (numComputes + numRayGens + numMissProgs);
                   memcpy(mapped + recordOffset, shaderHandleStorage.data() + handleOffset, handleSize);
@@ -2717,6 +2903,7 @@ struct Context {
                   }
                 }
               }
+              geomIDOffset += aabbAccel->geometries.size();
             }
             
             else {
@@ -2819,7 +3006,7 @@ struct Context {
 
     // Hit groups
 
-    // Go over all TLAS
+    // Go over all TLAS by order they were created
     for (int tlasID = 0; tlasID < accels.size(); ++tlasID) {
       Accel *tlas = accels[tlasID];
       if (!tlas) continue;
@@ -3516,16 +3703,41 @@ gprtInstanceAccelCreate(GPRTContext _context,
 
 GPRT_API void 
 gprtInstanceAccelSetTransforms(GPRTAccel instanceAccel,
-                               GPRTBuffer _transforms//,
+                               GPRTBuffer _transforms,
+                               size_t count,
+                               size_t stride,
+                               size_t offset
+                               )
+{
+  LOG_API_CALL();
+  InstanceAccel *accel = (InstanceAccel*)instanceAccel;
+  Buffer *transforms = (Buffer*)_transforms;
+  accel->setTransforms(transforms, count, stride, offset);
+  LOG("Setting instance accel transforms...");
+}
+
+GPRT_API void 
+gprtInstanceAccelSetReferences(GPRTAccel instanceAccel,
+                               GPRTBuffer _references//,
                                // size_t offset, // maybe I can support these too?
                                // size_t stride  // maybe I can support these too?
                                )
 {
   LOG_API_CALL();
   InstanceAccel *accel = (InstanceAccel*)instanceAccel;
-  Buffer *transforms = (Buffer*)_transforms;
-  accel->setTransforms(transforms);
-  LOG("Setting instance accel transforms...");
+  Buffer *references = (Buffer*)_references;
+  accel->setReferences(references);
+  LOG("Setting instance accel references...");
+}
+
+GPRT_API void 
+gprtInstanceAccelSetNumGeometries(GPRTAccel instanceAccel, 
+                                  size_t numGeometries)
+{
+  LOG_API_CALL();
+  InstanceAccel *accel = (InstanceAccel*)instanceAccel;
+  accel->setNumGeometries(numGeometries);
+  LOG("Setting instance accel references...");
 }
 
 GPRT_API void
@@ -3551,6 +3763,12 @@ GPRT_API void gprtAccelBuild(GPRTContext _context, GPRTAccel _accel)
 GPRT_API void gprtAccelRefit(GPRTContext _context, GPRTAccel accel)
 {
   GPRT_NOTIMPLEMENTED;
+}
+
+GPRT_API uint64_t gprtAccelGetReference(GPRTAccel _accel)
+{
+  Accel *accel = (Accel*)_accel;
+  return uint64_t(accel->address);
 }
 
 GPRT_API void gprtBuildShaderBindingTable(GPRTContext _context,

--- a/gprt/gprt.cpp
+++ b/gprt/gprt.cpp
@@ -1574,14 +1574,10 @@ struct InstanceAccel : public Accel {
 
   void setTransforms(
     Buffer* transforms,
-    size_t count,
     size_t stride,
     size_t offset
     ) 
   {
-    if (count != this->numInstances) {
-      GPRT_RAISE("Error, transform count must match number of instances!");
-    }
     // assuming no motion blurred triangles for now, so we assume 1 transform per instance
     this->transforms.buffer = transforms;
     this->transforms.stride = stride;
@@ -3702,9 +3698,22 @@ gprtInstanceAccelCreate(GPRTContext _context,
 }
 
 GPRT_API void 
+gprtInstanceAccelSet3x4Transforms(GPRTAccel instanceAccel,
+                                  GPRTBuffer transforms)
+{
+  gprtInstanceAccelSetTransforms(instanceAccel, transforms, sizeof(float3x4), 0);
+}
+
+GPRT_API void 
+gprtInstanceAccelSet4x4Transforms(GPRTAccel instanceAccel,
+                                  GPRTBuffer transforms)
+{
+  gprtInstanceAccelSetTransforms(instanceAccel, transforms, sizeof(float4x4), 0);
+}
+
+GPRT_API void 
 gprtInstanceAccelSetTransforms(GPRTAccel instanceAccel,
                                GPRTBuffer _transforms,
-                               size_t count,
                                size_t stride,
                                size_t offset
                                )
@@ -3712,7 +3721,7 @@ gprtInstanceAccelSetTransforms(GPRTAccel instanceAccel,
   LOG_API_CALL();
   InstanceAccel *accel = (InstanceAccel*)instanceAccel;
   Buffer *transforms = (Buffer*)_transforms;
-  accel->setTransforms(transforms, count, stride, offset);
+  accel->setTransforms(transforms, stride, offset);
   LOG("Setting instance accel transforms...");
 }
 

--- a/gprt/gprt.cpp
+++ b/gprt/gprt.cpp
@@ -2134,18 +2134,6 @@ struct Context {
       if (accel->getType() == GPRT_INSTANCE_ACCEL) {
         InstanceAccel* tlas = (InstanceAccel*) accel;
         totalGeometries += tlas->getNumGeometries();
-        // // this is a problem, because instances here is a nullptr, set on device...
-        // for (int blasID = 0; blasID < tlas->instances.size(); ++blasID) {
-        //   Accel *blas = tlas->instances[blasID];
-        //   if (blas->getType() == GPRT_TRIANGLE_ACCEL) {
-        //     TriangleAccel *triAccel = (TriangleAccel*) blas;
-        //     totalGeometries += triAccel->geometries.size();
-        //   }
-        //   if (blas->getType() == GPRT_AABB_ACCEL) {
-        //     AABBAccel *aabbAccel = (AABBAccel*) blas;
-        //     totalGeometries += aabbAccel->geometries.size();
-        //   }
-        // }
       }
     }
 

--- a/gprt/gprt_device_code.hlsl
+++ b/gprt/gprt_device_code.hlsl
@@ -32,26 +32,45 @@ void __compute__gprtFillInstanceData( uint3 DTid : SV_DispatchThreadID )
   uint64_t transformBufferPtr = pc.r[1];
   uint64_t accelReferencesPtr = pc.r[2];
   uint64_t instanceShaderBindingTableRecordOffset = pc.r[3];
+  uint64_t transformOffset = pc.r[4];
+  uint64_t transformStride = pc.r[5];
+  uint64_t instanceOffsetsBufferPtr = pc.r[6];
 
   VkAccelerationStructureInstanceKHR instance;
   // float3x4 transform = vk::RawBufferLoad<float3x4>(
   //     transformBufferPtr + sizeof(float3x4) * DTid.x);;
   
   instance.instanceCustomIndex24Mask8 = 0 | 0xFF << 24;
-  instance.instanceShaderBindingTableRecordOffset24Flags8 = 
-    int(instanceShaderBindingTableRecordOffset) | 0x00 << 24;
 
-  // this is gross, but AMD has a bug where loading 3x4 transforms causes a random crash when creating shader modules.
-  instance.transforma = 
-    vk::RawBufferLoad<float4>(
-      transformBufferPtr + sizeof(float3x4) * DTid.x);
-  instance.transformb = 
-    vk::RawBufferLoad<float4>(
-      transformBufferPtr + sizeof(float3x4) * DTid.x + sizeof(float4));
-  instance.transformc = 
-    vk::RawBufferLoad<float4>(
-      transformBufferPtr + sizeof(float3x4) * DTid.x + sizeof(float4) + sizeof(float4));
-  
+  int blasOffset = vk::RawBufferLoad<int32_t>(
+    instanceOffsetsBufferPtr + sizeof(int32_t) * DTid.x
+  );
+
+  // printf("blas %d offset %d\n", DTid.x, instanceShaderBindingTableRecordOffset + blasOffset);
+
+  instance.instanceShaderBindingTableRecordOffset24Flags8 = 
+    int(instanceShaderBindingTableRecordOffset + blasOffset) | 0x00 << 24;
+
+  // If given transforms, copy them over.
+  if (transformBufferPtr != -1) {
+    // this is gross, but AMD has a bug where loading 3x4 transforms causes a random crash when creating shader modules.
+    instance.transforma = 
+      vk::RawBufferLoad<float4>(
+        transformBufferPtr + transformOffset + transformStride * DTid.x);
+    instance.transformb = 
+      vk::RawBufferLoad<float4>(
+        transformBufferPtr + transformOffset + transformStride * DTid.x + sizeof(float4));
+    instance.transformc = 
+      vk::RawBufferLoad<float4>(
+        transformBufferPtr + transformOffset + transformStride * DTid.x + sizeof(float4) + sizeof(float4));
+  }
+  // otherwise, assume identity.
+  else {
+    instance.transforma = float4(1.0, 0.0, 0.0, 0.0);
+    instance.transformb = float4(0.0, 1.0, 0.0, 0.0);
+    instance.transformc = float4(0.0, 0.0, 1.0, 0.0);
+  }
+
   instance.accelerationStructureReference = vk::RawBufferLoad<uint64_t>(
     accelReferencesPtr + sizeof(uint64_t) * DTid.x
   );
@@ -95,8 +114,3 @@ void __compute__gprtFillInstanceData( uint3 DTid : SV_DispatchThreadID )
     instance.accelerationStructureReference
   );
 }
-
-// GPRT_COMPUTE_PROGRAM(TEST)(uint3 tid)
-// {
-//   printf("%d\n", tid.x);
-// }

--- a/gprt/gprt_host.h
+++ b/gprt/gprt_host.h
@@ -294,6 +294,8 @@ typedef enum
    
    /* A type matching VkTransformMatrixKHR, row major 3x4 */
    GPRT_TRANSFORM=1400,
+   GPRT_TRANSFORM_3X4=GPRT_TRANSFORM,
+   GPRT_TRANSFORM_4X4=1401,
 
    /*! at least for now, use that for buffers with user-defined types:
      type then is "GPRT_USER_TYPE_BEGIN+sizeof(elementtype). Note
@@ -379,6 +381,8 @@ typedef enum
 
     else if (type == GPRT_ACCEL) return 2 * sizeof(uint64_t);
     else if (type == GPRT_TRANSFORM) return sizeof(float) * 3 * 4;
+    else if (type == GPRT_TRANSFORM_3X4) return sizeof(float) * 3 * 4;
+    else if (type == GPRT_TRANSFORM_4X4) return sizeof(float) * 4 * 4;
 
     // User Types have size encoded in their type enum
     else if (type > GPRT_USER_TYPE_BEGIN) return type - GPRT_USER_TYPE_BEGIN;
@@ -597,6 +601,7 @@ gprtTrianglesAccelCreate(GPRTContext context,
 
 GPRT_API void 
 gprtTrianglesAccelSetTransforms(GPRTAccel trianglesAccel,
+                                GPRTDataType type,
                                 GPRTBuffer transforms//,
                                 // size_t offset, // maybe I can support these too?
                                 // size_t stride  // maybe I can support these too?
@@ -645,9 +650,10 @@ gprtInstanceAccelCreate(GPRTContext context,
 
 GPRT_API void 
 gprtInstanceAccelSetTransforms(GPRTAccel instanceAccel,
-                               GPRTBuffer transforms//,
-                               // size_t offset, // maybe I can support these too?
-                               // size_t stride  // maybe I can support these too?
+                               GPRTBuffer transforms,
+                               size_t count,
+                               size_t stride,
+                               size_t offset
                                );
 
 /*! sets the list of IDs to use for the child instnaces. By default
@@ -743,6 +749,9 @@ gprtBufferMap(GPRTBuffer buffer, int deviceID GPRT_IF_CPP(=0));
 
 GPRT_API void
 gprtBufferUnmap(GPRTBuffer buffer, int deviceID GPRT_IF_CPP(=0));
+
+GPRT_API void
+gprtRayGenLaunch1D(GPRTContext context, GPRTRayGen rayGen, int dims_x);
 
 /*! Executes a ray tracing pipeline with the given raygen program.
   This call will block until the raygen program returns. */

--- a/gprt/gprt_host.h
+++ b/gprt/gprt_host.h
@@ -599,14 +599,6 @@ gprtTrianglesAccelCreate(GPRTContext context,
                             GPRTGeom   *arrayOfChildGeoms,
                             unsigned int flags GPRT_IF_CPP(=0));
 
-GPRT_API void 
-gprtTrianglesAccelSetTransforms(GPRTAccel trianglesAccel,
-                                GPRTDataType type,
-                                GPRTBuffer transforms//,
-                                // size_t offset, // maybe I can support these too?
-                                // size_t stride  // maybe I can support these too?
-                                );
-
 // // ------------------------------------------------------------------
 // /*! create a new acceleration structure for "curves" geometries.
 
@@ -651,10 +643,17 @@ gprtInstanceAccelCreate(GPRTContext context,
 GPRT_API void 
 gprtInstanceAccelSetTransforms(GPRTAccel instanceAccel,
                                GPRTBuffer transforms,
-                               size_t count,
                                size_t stride,
                                size_t offset
                                );
+
+GPRT_API void 
+gprtInstanceAccelSet3x4Transforms(GPRTAccel instanceAccel,
+                                  GPRTBuffer transforms);
+
+GPRT_API void 
+gprtInstanceAccelSet4x4Transforms(GPRTAccel instanceAccel,
+                                  GPRTBuffer transforms);
 
 /*! sets the list of IDs to use for the child instnaces. By default
     the instance ID of child #i is simply i, but optix allows to

--- a/samples/cmd01-simpleTriangles/hostCode.cpp
+++ b/samples/cmd01-simpleTriangles/hostCode.cpp
@@ -147,7 +147,7 @@ int main(int ac, char **av)
   gprtAccelBuild(context, trianglesAccel);
 
   GPRTAccel world = gprtInstanceAccelCreate(context,1,&trianglesAccel);
-  gprtInstanceAccelSetTransforms(world, transformBuffer);
+  gprtInstanceAccelSetTransforms(world, transformBuffer, 1, sizeof(float3x4), 0);
   gprtAccelBuild(context, world);
 
   // ##################################################################

--- a/samples/cmd01-simpleTriangles/hostCode.cpp
+++ b/samples/cmd01-simpleTriangles/hostCode.cpp
@@ -147,7 +147,7 @@ int main(int ac, char **av)
   gprtAccelBuild(context, trianglesAccel);
 
   GPRTAccel world = gprtInstanceAccelCreate(context,1,&trianglesAccel);
-  gprtInstanceAccelSetTransforms(world, transformBuffer, 1, sizeof(float3x4), 0);
+  gprtInstanceAccelSet3x4Transforms(world, transformBuffer);
   gprtAccelBuild(context, world);
 
   // ##################################################################

--- a/samples/cmd02-simpleAABBs/hostCode.cpp
+++ b/samples/cmd02-simpleAABBs/hostCode.cpp
@@ -137,7 +137,7 @@ int main(int ac, char **av)
   gprtAccelBuild(context, aabbAccel);
 
   GPRTAccel world = gprtInstanceAccelCreate(context,1,&aabbAccel);
-  gprtInstanceAccelSetTransforms(world, transformBuffer);
+  gprtInstanceAccelSetTransforms(world, transformBuffer, 1, sizeof(float3x4), 0);
   gprtAccelBuild(context, world);
 
   // ##################################################################

--- a/samples/cmd02-simpleAABBs/hostCode.cpp
+++ b/samples/cmd02-simpleAABBs/hostCode.cpp
@@ -137,7 +137,7 @@ int main(int ac, char **av)
   gprtAccelBuild(context, aabbAccel);
 
   GPRTAccel world = gprtInstanceAccelCreate(context,1,&aabbAccel);
-  gprtInstanceAccelSetTransforms(world, transformBuffer, 1, sizeof(float3x4), 0);
+  gprtInstanceAccelSet3x4Transforms(world, transformBuffer);
   gprtAccelBuild(context, world);
 
   // ##################################################################

--- a/samples/int01-simpleTriangles/hostCode.cpp
+++ b/samples/int01-simpleTriangles/hostCode.cpp
@@ -150,7 +150,7 @@ int main(int ac, char **av)
   gprtAccelBuild(context, trianglesAccel);
 
   GPRTAccel world = gprtInstanceAccelCreate(context,1,&trianglesAccel);
-  gprtInstanceAccelSetTransforms(world, transformBuffer);
+  gprtInstanceAccelSetTransforms(world, transformBuffer, 1, sizeof(float3x4), 0);
   gprtAccelBuild(context, world);
 
   // ##################################################################

--- a/samples/int01-simpleTriangles/hostCode.cpp
+++ b/samples/int01-simpleTriangles/hostCode.cpp
@@ -150,7 +150,7 @@ int main(int ac, char **av)
   gprtAccelBuild(context, trianglesAccel);
 
   GPRTAccel world = gprtInstanceAccelCreate(context,1,&trianglesAccel);
-  gprtInstanceAccelSetTransforms(world, transformBuffer, 1, sizeof(float3x4), 0);
+  gprtInstanceAccelSet3x4Transforms(world, transformBuffer);
   gprtAccelBuild(context, world);
 
   // ##################################################################

--- a/samples/int02-simpleAABBs/hostCode.cpp
+++ b/samples/int02-simpleAABBs/hostCode.cpp
@@ -140,7 +140,7 @@ int main(int ac, char **av)
   gprtAccelBuild(context, aabbAccel);
 
   GPRTAccel world = gprtInstanceAccelCreate(context,1,&aabbAccel);
-  gprtInstanceAccelSetTransforms(world, transformBuffer, 1, sizeof(float3x4), 0);
+  gprtInstanceAccelSet3x4Transforms(world, transformBuffer);
   gprtAccelBuild(context, world);
 
   // ##################################################################

--- a/samples/int02-simpleAABBs/hostCode.cpp
+++ b/samples/int02-simpleAABBs/hostCode.cpp
@@ -140,7 +140,7 @@ int main(int ac, char **av)
   gprtAccelBuild(context, aabbAccel);
 
   GPRTAccel world = gprtInstanceAccelCreate(context,1,&aabbAccel);
-  gprtInstanceAccelSetTransforms(world, transformBuffer);
+  gprtInstanceAccelSetTransforms(world, transformBuffer, 1, sizeof(float3x4), 0);
   gprtAccelBuild(context, world);
 
   // ##################################################################

--- a/samples/int04-computeAABBs/hostCode.cpp
+++ b/samples/int04-computeAABBs/hostCode.cpp
@@ -176,7 +176,7 @@ int main(int ac, char **av)
   GPRTBuffer transformBuffer
     = gprtDeviceBufferCreate(context,GPRT_TRANSFORM,1,transform);
   GPRTAccel world = gprtInstanceAccelCreate(context,1,&aabbAccel);
-  gprtInstanceAccelSetTransforms(world, transformBuffer);
+  gprtInstanceAccelSetTransforms(world, transformBuffer, 1, sizeof(float3x4), 0);
   gprtAccelBuild(context, world);
 
   // ----------- set variables  ----------------------------

--- a/samples/int04-computeAABBs/hostCode.cpp
+++ b/samples/int04-computeAABBs/hostCode.cpp
@@ -176,7 +176,7 @@ int main(int ac, char **av)
   GPRTBuffer transformBuffer
     = gprtDeviceBufferCreate(context,GPRT_TRANSFORM,1,transform);
   GPRTAccel world = gprtInstanceAccelCreate(context,1,&aabbAccel);
-  gprtInstanceAccelSetTransforms(world, transformBuffer, 1, sizeof(float3x4), 0);
+  gprtInstanceAccelSet3x4Transforms(world, transformBuffer);
   gprtAccelBuild(context, world);
 
   // ----------- set variables  ----------------------------

--- a/samples/int05-computePrimitive/hostCode.cpp
+++ b/samples/int05-computePrimitive/hostCode.cpp
@@ -176,7 +176,7 @@ int main(int ac, char **av)
   GPRTBuffer transformBuffer
     = gprtDeviceBufferCreate(context,GPRT_TRANSFORM,1,transform);
   GPRTAccel world = gprtInstanceAccelCreate(context,1,&aabbAccel);
-  gprtInstanceAccelSetTransforms(world, transformBuffer);
+  gprtInstanceAccelSetTransforms(world, transformBuffer, 1, sizeof(float3x4), 0);
   gprtAccelBuild(context, world);
 
   // ----------- set variables  ----------------------------

--- a/samples/int05-computePrimitive/hostCode.cpp
+++ b/samples/int05-computePrimitive/hostCode.cpp
@@ -176,7 +176,7 @@ int main(int ac, char **av)
   GPRTBuffer transformBuffer
     = gprtDeviceBufferCreate(context,GPRT_TRANSFORM,1,transform);
   GPRTAccel world = gprtInstanceAccelCreate(context,1,&aabbAccel);
-  gprtInstanceAccelSetTransforms(world, transformBuffer, 1, sizeof(float3x4), 0);
+  gprtInstanceAccelSet3x4Transforms(world, transformBuffer);
   gprtAccelBuild(context, world);
 
   // ----------- set variables  ----------------------------

--- a/samples/int07-doublePrecision/hostCode.cpp
+++ b/samples/int07-doublePrecision/hostCode.cpp
@@ -177,7 +177,7 @@ int main(int ac, char **av)
   GPRTBuffer transformBuffer
     = gprtDeviceBufferCreate(context,GPRT_TRANSFORM,1,transform);
   GPRTAccel world = gprtInstanceAccelCreate(context,1,&aabbAccel);
-  gprtInstanceAccelSetTransforms(world, transformBuffer);
+  gprtInstanceAccelSetTransforms(world, transformBuffer, 1, sizeof(float3x4), 0);
   gprtAccelBuild(context, world);
 
   // ----------- set variables  ----------------------------

--- a/samples/int07-doublePrecision/hostCode.cpp
+++ b/samples/int07-doublePrecision/hostCode.cpp
@@ -177,7 +177,7 @@ int main(int ac, char **av)
   GPRTBuffer transformBuffer
     = gprtDeviceBufferCreate(context,GPRT_TRANSFORM,1,transform);
   GPRTAccel world = gprtInstanceAccelCreate(context,1,&aabbAccel);
-  gprtInstanceAccelSetTransforms(world, transformBuffer, 1, sizeof(float3x4), 0);
+  gprtInstanceAccelSet3x4Transforms(world, transformBuffer);
   gprtAccelBuild(context, world);
 
   // ----------- set variables  ----------------------------

--- a/samples/int08-multipleTLAS/hostCode.cpp
+++ b/samples/int08-multipleTLAS/hostCode.cpp
@@ -208,13 +208,13 @@ int main(int ac, char **av)
   GPRTAccel tetrahedraAccel = gprtAABBAccelCreate(context,1,&tetrahedraGeom);
   gprtAccelBuild(context, tetrahedraAccel);
   GPRTAccel tetrahedraTLAS = gprtInstanceAccelCreate(context,1,&tetrahedraAccel);
-  gprtInstanceAccelSetTransforms(tetrahedraTLAS, tetrahedraTransformBuffer, 1, sizeof(float3x4), 0);
+  gprtInstanceAccelSet3x4Transforms(tetrahedraTLAS, tetrahedraTransformBuffer);
   gprtAccelBuild(context, tetrahedraTLAS);
 
   GPRTAccel trianglesAccel = gprtTrianglesAccelCreate(context,1,&trianglesGeom);
   gprtAccelBuild(context, trianglesAccel);
   GPRTAccel trianglesTLAS = gprtInstanceAccelCreate(context,1,&trianglesAccel);
-  gprtInstanceAccelSetTransforms(trianglesTLAS, triangleTransformBuffer, 1, sizeof(float3x4), 0);
+  gprtInstanceAccelSet3x4Transforms(trianglesTLAS, triangleTransformBuffer);
   gprtAccelBuild(context, trianglesTLAS);
 
 

--- a/samples/int08-multipleTLAS/hostCode.cpp
+++ b/samples/int08-multipleTLAS/hostCode.cpp
@@ -208,15 +208,14 @@ int main(int ac, char **av)
   GPRTAccel tetrahedraAccel = gprtAABBAccelCreate(context,1,&tetrahedraGeom);
   gprtAccelBuild(context, tetrahedraAccel);
   GPRTAccel tetrahedraTLAS = gprtInstanceAccelCreate(context,1,&tetrahedraAccel);
-  gprtInstanceAccelSetTransforms(tetrahedraTLAS, tetrahedraTransformBuffer);
+  gprtInstanceAccelSetTransforms(tetrahedraTLAS, tetrahedraTransformBuffer, 1, sizeof(float3x4), 0);
   gprtAccelBuild(context, tetrahedraTLAS);
 
   GPRTAccel trianglesAccel = gprtTrianglesAccelCreate(context,1,&trianglesGeom);
   gprtAccelBuild(context, trianglesAccel);
   GPRTAccel trianglesTLAS = gprtInstanceAccelCreate(context,1,&trianglesAccel);
-  gprtInstanceAccelSetTransforms(trianglesTLAS, triangleTransformBuffer);
+  gprtInstanceAccelSetTransforms(trianglesTLAS, triangleTransformBuffer, 1, sizeof(float3x4), 0);
   gprtAccelBuild(context, trianglesTLAS);
-  
 
 
   // ##################################################################


### PR DESCRIPTION
This PR corrects a bug breaking multiple BLAS from working in one TLAS

We also change the instance transform API to now properly take count, stride and offset. This enables the use of 4x4 or 3x4 row major transform matrices.

The hints to find dxc have also changed to prioritize finding dxc in the vulkan sdk