### PR TITLE
Add support for official Vulkan swapchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
       shell: bash
       run: |
         sudo apt -y update
-        sudo apt install -y xorg-dev \
+        sudo apt install -y libx11-xcb-dev \
+                            xorg-dev \
                             libxinerama-dev \
                             libglu1-mesa-dev \
                             freeglut3-dev \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ GPRT is a ray tracing API that wraps the Vulkan ray tracing interface.
 ## Dependencies
 
   - CMake
+  - C++17
   - Vulkan SDK (>= 1.3.231.1)
 
 ## Documentation

--- a/gprt/CMakeLists.txt
+++ b/gprt/CMakeLists.txt
@@ -64,6 +64,7 @@ target_link_libraries(gprt
     PUBLIC
     ${Vulkan_LIBRARY}
     gprtDeviceCode
+    glfw
 )
 
 set_target_properties(gprt PROPERTIES LINKER_LANGUAGE CXX)
@@ -74,5 +75,7 @@ target_include_directories(gprt
     ${PROJECT_SOURCE_DIR}
     ${CMAKE_CURRENT_LIST_DIR}
 )
+
+target_compile_features(gprt PRIVATE cxx_std_17)
 
 add_library(gprt::gprt ALIAS gprt)

--- a/gprt/cmake/FindXCB.cmake
+++ b/gprt/cmake/FindXCB.cmake
@@ -1,0 +1,51 @@
+# - FindXCB
+#
+# Copyright 2015 Valve Coporation
+
+find_package(PkgConfig)
+
+if(NOT XCB_FIND_COMPONENTS)
+    set(XCB_FIND_COMPONENTS xcb)
+endif()
+
+include(FindPackageHandleStandardArgs)
+set(XCB_FOUND true)
+set(XCB_INCLUDE_DIRS "")
+set(XCB_LIBRARIES "")
+foreach(comp ${XCB_FIND_COMPONENTS})
+    # component name
+    string(TOUPPER ${comp} compname)
+    string(REPLACE "-" "_" compname ${compname})
+    # header name
+    string(REPLACE "xcb-" "" headername xcb/${comp}.h)
+    # library name
+    set(libname ${comp})
+
+    pkg_check_modules(PC_${comp} QUIET ${comp})
+
+    find_path(${compname}_INCLUDE_DIR NAMES ${headername}
+        HINTS
+        ${PC_${comp}_INCLUDEDIR}
+        ${PC_${comp}_INCLUDE_DIRS}
+        )
+
+    find_library(${compname}_LIBRARY NAMES ${libname}
+        HINTS
+        ${PC_${comp}_LIBDIR}
+        ${PC_${comp}_LIBRARY_DIRS}
+        )
+
+    find_package_handle_standard_args(${comp}
+        FOUND_VAR ${comp}_FOUND
+        REQUIRED_VARS ${compname}_INCLUDE_DIR ${compname}_LIBRARY)
+    mark_as_advanced(${compname}_INCLUDE_DIR ${compname}_LIBRARY)
+
+    list(APPEND XCB_INCLUDE_DIRS ${${compname}_INCLUDE_DIR})
+    list(APPEND XCB_LIBRARIES ${${compname}_LIBRARY})
+
+    if(NOT ${comp}_FOUND)
+        set(XCB_FOUND false)
+    endif()
+endforeach()
+
+list(REMOVE_DUPLICATES XCB_INCLUDE_DIRS)

--- a/gprt/gprt.cpp
+++ b/gprt/gprt.cpp
@@ -2262,35 +2262,6 @@ struct Context {
 
     instanceCreateInfo.ppEnabledLayerNames = nullptr;
     instanceCreateInfo.enabledLayerCount = 0;
-    // Nate 11/29/2022 - not sure why, but adding VK_LAYER_KHRONOS_validation causes
-    // nsight graphics to crash, and we are unable to profile...
-
-    // We can instead use the vulkan configurator tool to enable validation.
-
-    // // The VK_LAYER_KHRONOS_validation contains all current validation functionality.
-    // // Note that on Android this layer requires at least NDK r20
-    // const char* validationLayerName = "VK_LAYER_KHRONOS_validation";
-    // if (validation())
-    // {
-    //   // Check if this layer is available at instance level
-    //   uint32_t instanceLayerCount;
-    //   vkEnumerateInstanceLayerProperties(&instanceLayerCount, nullptr);
-    //   std::vector<VkLayerProperties> instanceLayerProperties(instanceLayerCount);
-    //   vkEnumerateInstanceLayerProperties(&instanceLayerCount, instanceLayerProperties.data());
-    //   bool validationLayerPresent = false;
-    //   for (VkLayerProperties layer : instanceLayerProperties) {
-    //     if (strcmp(layer.layerName, validationLayerName) == 0) {
-    //       validationLayerPresent = true;
-    //       break;
-    //     }
-    //   }
-    //   if (validationLayerPresent) {
-    //     instanceCreateInfo.ppEnabledLayerNames = &validationLayerName;
-    //     instanceCreateInfo.enabledLayerCount = 1;
-    //   } else {
-    //     std::cerr << "Validation layer VK_LAYER_KHRONOS_validation not present, validation is disabled";
-    //   }
-    // }
 
     VkResult err;
 
@@ -2298,17 +2269,6 @@ struct Context {
     if (err) {
       GPRT_RAISE("failed to create instance! : \n" + errorString(err));
     }
-
-    // err = createDebugUtilsMessenger(instance,
-    //     info.debug_callback,
-    //     info.debug_message_severity,
-    //     info.debug_message_type,
-    //     &instance.debug_messenger,
-    //     info.allocation_callbacks);
-    // if (err) {
-    //   GPRT_RAISE("failed to debug messenger callback! : \n" + errorString(err));
-    // }
-
 
     /// 1.5 - create a window and surface if requested
     if (requestedFeatures.window) {

--- a/gprt/gprt.cpp
+++ b/gprt/gprt.cpp
@@ -3458,13 +3458,6 @@ struct Context {
         throw std::invalid_argument("unsupported layout transition!");
     }
 
-    // } else if (oldLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
-    //     barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-    //     barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-
-    //     sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
-    //     destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-
     vkCmdPipelineBarrier(
         commandBuffer,
         sourceStage, destinationStage,

--- a/gprt/gprt.cpp
+++ b/gprt/gprt.cpp
@@ -2312,6 +2312,8 @@ struct Context {
     /// 1.5 - create a window and surface if requested
     if (requestedFeatures.window) {
       glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+      // todo, allow the window to resize and recreate swapchain
+      glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE); 
       window = glfwCreateWindow(
         requestedFeatures.windowProperties.initialWidth, 
         requestedFeatures.windowProperties.initialHeight, 

--- a/gprt/gprt.cpp
+++ b/gprt/gprt.cpp
@@ -28,6 +28,7 @@
 #include <map>
 #include <set>
 #include <limits>
+#include <climits>
 #include <algorithm>
 
 #include <regex>
@@ -2443,15 +2444,15 @@ struct Context {
     for (uint32_t i = 0; i < gpuCount; i++) {
       VkPhysicalDeviceProperties deviceProperties;
       vkGetPhysicalDeviceProperties(physicalDevices[i], &deviceProperties);
-      LOG("Device [" << i << "] : " << deviceProperties.deviceName);
-      // std::cout << " Type: " << physicalDeviceTypeString(deviceProperties.deviceType) << "\n";
-      // std::cout << " API: " << (deviceProperties.apiVersion >> 22) << "."
-      //   << ((deviceProperties.apiVersion >> 12) & 0x3ff) << "."
-      //   << (deviceProperties.apiVersion & 0xfff) << "\n";
+      std::string message = std::string("Device [") + std::to_string(i) + std::string("] : ") + std::string(deviceProperties.deviceName);
+      message += std::string(", Type : ") + physicalDeviceTypeString(deviceProperties.deviceType);
+      message += std::string(", API : ") + std::to_string(deviceProperties.apiVersion >> 22) + std::string(".")
+               + std::to_string(((deviceProperties.apiVersion >> 12) & 0x3ff)) + std::string(".")
+               + std::to_string(deviceProperties.apiVersion & 0xfff);
+      LOG(message);
       
       if (checkDeviceExtensionSupport(physicalDevices[i], enabledDeviceExtensions)) {
         usableDevices.push_back(i);
-        // break;
       } else {
         /* Explain why we aren't using this device */
         for (const char* enabledExtension : enabledDeviceExtensions)
@@ -2462,22 +2463,6 @@ struct Context {
           }
         }
       }
-
-      // // Get ray tracing pipeline properties
-      // VkPhysicalDeviceRayTracingPipelinePropertiesKHR  rayTracingPipelineProperties{};
-      // rayTracingPipelineProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR;
-      // VkPhysicalDeviceProperties2 deviceProperties2{};
-      // deviceProperties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
-      // deviceProperties2.pNext = &rayTracingPipelineProperties;
-      // vkGetPhysicalDeviceProperties2(physicalDevices[i], &deviceProperties2);
-
-      // // Get acceleration structure properties
-      // VkPhysicalDeviceAccelerationStructureFeaturesKHR accelerationStructureFeatures{};
-      // accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
-      // VkPhysicalDeviceFeatures2 deviceFeatures2{};
-      // deviceFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-      // deviceFeatures2.pNext = &accelerationStructureFeatures;
-      // vkGetPhysicalDeviceFeatures2(physicalDevices[i], &deviceFeatures2);
     }
 
     if (usableDevices.size() == 0) {

--- a/gprt/gprt.cpp
+++ b/gprt/gprt.cpp
@@ -2259,30 +2259,37 @@ struct Context {
       instanceCreateInfo.ppEnabledExtensionNames = instanceExtensions.data();
     }
 
-    // The VK_LAYER_KHRONOS_validation contains all current validation functionality.
-    // Note that on Android this layer requires at least NDK r20
-    const char* validationLayerName = "VK_LAYER_KHRONOS_validation";
-    if (validation())
-    {
-      // Check if this layer is available at instance level
-      uint32_t instanceLayerCount;
-      vkEnumerateInstanceLayerProperties(&instanceLayerCount, nullptr);
-      std::vector<VkLayerProperties> instanceLayerProperties(instanceLayerCount);
-      vkEnumerateInstanceLayerProperties(&instanceLayerCount, instanceLayerProperties.data());
-      bool validationLayerPresent = false;
-      for (VkLayerProperties layer : instanceLayerProperties) {
-        if (strcmp(layer.layerName, validationLayerName) == 0) {
-          validationLayerPresent = true;
-          break;
-        }
-      }
-      if (validationLayerPresent) {
-        instanceCreateInfo.ppEnabledLayerNames = &validationLayerName;
-        instanceCreateInfo.enabledLayerCount = 1;
-      } else {
-        std::cerr << "Validation layer VK_LAYER_KHRONOS_validation not present, validation is disabled";
-      }
-    }
+    instanceCreateInfo.ppEnabledLayerNames = nullptr;
+    instanceCreateInfo.enabledLayerCount = 0;
+    // Nate 11/29/2022 - not sure why, but adding VK_LAYER_KHRONOS_validation causes
+    // nsight graphics to crash, and we are unable to profile...
+
+    // We can instead use the vulkan configurator tool to enable validation.
+
+    // // The VK_LAYER_KHRONOS_validation contains all current validation functionality.
+    // // Note that on Android this layer requires at least NDK r20
+    // const char* validationLayerName = "VK_LAYER_KHRONOS_validation";
+    // if (validation())
+    // {
+    //   // Check if this layer is available at instance level
+    //   uint32_t instanceLayerCount;
+    //   vkEnumerateInstanceLayerProperties(&instanceLayerCount, nullptr);
+    //   std::vector<VkLayerProperties> instanceLayerProperties(instanceLayerCount);
+    //   vkEnumerateInstanceLayerProperties(&instanceLayerCount, instanceLayerProperties.data());
+    //   bool validationLayerPresent = false;
+    //   for (VkLayerProperties layer : instanceLayerProperties) {
+    //     if (strcmp(layer.layerName, validationLayerName) == 0) {
+    //       validationLayerPresent = true;
+    //       break;
+    //     }
+    //   }
+    //   if (validationLayerPresent) {
+    //     instanceCreateInfo.ppEnabledLayerNames = &validationLayerName;
+    //     instanceCreateInfo.enabledLayerCount = 1;
+    //   } else {
+    //     std::cerr << "Validation layer VK_LAYER_KHRONOS_validation not present, validation is disabled";
+    //   }
+    // }
 
     VkResult err;
 

--- a/gprt/gprt.cpp
+++ b/gprt/gprt.cpp
@@ -2868,6 +2868,11 @@ struct Context {
       swapchainImages.resize(surfaceImageCount);
       vkGetSwapchainImagesKHR(logicalDevice, swapchain, &surfaceImageCount, swapchainImages.data());
 
+      /* Transition all images to presentable */
+      for (uint32_t i = 0; i < swapchainImages.size(); ++i) {
+        transitionImageLayout(swapchainImages[i], surfaceFormat.format, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+      }
+
       // And acquire the first image to use
       vkAcquireNextImageKHR(logicalDevice, swapchain, UINT64_MAX, 
         imageAvailableSemaphore, VK_NULL_HANDLE, &currentImageIndex);
@@ -3379,6 +3384,96 @@ struct Context {
     err = vkCreateComputePipelines(logicalDevice, 
       cache, 1, &computePipelineCreateInfo, nullptr, &fillInstanceDataStage.pipeline);
     //todo, destroy the above stuff
+  }
+
+  
+  VkCommandBuffer beginSingleTimeCommands(VkCommandPool pool) {
+    VkCommandBufferAllocateInfo allocInfo{};
+    allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    allocInfo.commandPool = pool;
+    allocInfo.commandBufferCount = 1;
+
+    VkCommandBuffer commandBuffer;
+    vkAllocateCommandBuffers(logicalDevice, &allocInfo, &commandBuffer);
+
+    VkCommandBufferBeginInfo beginInfo{};
+    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+    vkBeginCommandBuffer(commandBuffer, &beginInfo);
+
+    return commandBuffer;
+  }
+
+  void endSingleTimeCommands(VkCommandBuffer commandBuffer, VkCommandPool pool, VkQueue queue) {
+      vkEndCommandBuffer(commandBuffer);
+
+      VkSubmitInfo submitInfo{};
+      submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+      submitInfo.commandBufferCount = 1;
+      submitInfo.pCommandBuffers = &commandBuffer;
+
+      vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE);
+      vkQueueWaitIdle(queue);
+
+      vkFreeCommandBuffers(logicalDevice, pool, 1, &commandBuffer);
+  }
+
+  void transitionImageLayout(VkImage image, VkFormat format, VkImageLayout oldLayout, VkImageLayout newLayout) {
+    VkCommandBuffer commandBuffer = beginSingleTimeCommands(graphicsCommandPool);
+
+    VkImageMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    
+    // If this layout is "VK_IMAGE_LAYOUT_UNDEFINED", we might lose the contents of the original 
+    // image. I'm assuming this is ok.
+    barrier.oldLayout = oldLayout;
+
+    // The new layout for the image
+    barrier.newLayout = newLayout;
+
+    // If we're transferring which queue owns this image, we need to set these.
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+
+    // specify the image that is affected and the specific parts of that image.
+    barrier.image = image;
+    barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrier.subresourceRange.baseMipLevel = 0;
+    barrier.subresourceRange.levelCount = 1;
+    barrier.subresourceRange.baseArrayLayer = 0;
+    barrier.subresourceRange.layerCount = 1;
+
+    VkPipelineStageFlags sourceStage;
+    VkPipelineStageFlags destinationStage;
+
+    if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) {
+        barrier.srcAccessMask = 0;
+        barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+
+        sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+        destinationStage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+    // } else if (oldLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
+    //     barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    //     barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+    //     sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    //     destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+    } else {
+        throw std::invalid_argument("unsupported layout transition!");
+    }
+
+    vkCmdPipelineBarrier(
+        commandBuffer,
+        sourceStage, destinationStage,
+        0,
+        0, nullptr,
+        0, nullptr,
+        1, &barrier
+    );
+
+    endSingleTimeCommands(commandBuffer, graphicsCommandPool, graphicsQueue);
   }
 };
 

--- a/gprt/gprt_host.h
+++ b/gprt/gprt_host.h
@@ -492,8 +492,30 @@ GPRT_API void gprtBuildPipeline(GPRTContext context);
 GPRT_API void gprtBuildShaderBindingTable(GPRTContext context,
                          GPRTBuildSBTFlags flags GPRT_IF_CPP(=GPRT_SBT_ALL));
 
-/** Tells the GPRT to request support for a window when creating a context.  */
-GPRT_API void gprtRequestSwapchain();
+/** Tells the GPRT to create a window when once the context is made. 
+ * @param initialWidth The width of the window in screen coordinates
+ * @param initialHeight The height of the window in screen coordinates
+ * @param title The title to put in the top bar of the window
+*/
+GPRT_API void gprtRequestWindow(
+  uint32_t initialWidth, 
+  uint32_t initialHeight, 
+  const char *title);
+
+/** If a window was requested, @returns true if the window's close button 
+ * was clicked. This function can be called from any thread.
+ * 
+ * If a window was not requested (ie headless), this function always @returns
+ * true.
+*/
+GPRT_API bool gprtWindowShouldClose(GPRTContext context);
+
+/** If a window was requested, presents the currently rendered image to 
+ * the window, potentially waiting for the screen to update before swapping.
+ * 
+ * If a window was not requested (ie headless), this function does nothing. 
+*/
+GPRT_API void gprtSwapBuffers(GPRTContext context);
 
 /** creates a new device context with the gives list of devices.
 

--- a/gprt/gprt_host.h
+++ b/gprt/gprt_host.h
@@ -510,12 +510,13 @@ GPRT_API void gprtRequestWindow(
 */
 GPRT_API bool gprtWindowShouldClose(GPRTContext context);
 
-/** If a window was requested, presents the currently rendered image to 
- * the window, potentially waiting for the screen to update before swapping.
+/** If a window was requested, this call interprets the given buffer as 
+ * a B8G8R8A8 SRGB image sorted in row major buffer, and presents the contents 
+ * to the window, potentially waiting for the screen to update before swapping.
  * 
  * If a window was not requested (ie headless), this function does nothing. 
 */
-GPRT_API void gprtSwapBuffers(GPRTContext context);
+GPRT_API void gprtPresentBuffer(GPRTContext context, GPRTBuffer buffer);
 
 /** creates a new device context with the gives list of devices.
 

--- a/gprt/gprt_host.h
+++ b/gprt/gprt_host.h
@@ -492,6 +492,9 @@ GPRT_API void gprtBuildPipeline(GPRTContext context);
 GPRT_API void gprtBuildShaderBindingTable(GPRTContext context,
                          GPRTBuildSBTFlags flags GPRT_IF_CPP(=GPRT_SBT_ALL));
 
+/** Tells the GPRT to request support for a window when creating a context.  */
+GPRT_API void gprtRequestSwapchain();
+
 /** creates a new device context with the gives list of devices.
 
   If requested device IDs list if null it implicitly refers to the
@@ -774,6 +777,7 @@ GPRT_API void gprtBeginProfile(GPRTContext context);
 
 // returned results are in nanoseconds
 GPRT_API float gprtEndProfile(GPRTContext context);
+
 #ifdef __cplusplus
 // ------------------------------------------------------------------
 // setters for variables of type "bool" (bools only on c++)

--- a/samples/int00-rayGenOnly/hostCode.cpp
+++ b/samples/int00-rayGenOnly/hostCode.cpp
@@ -120,7 +120,7 @@ int main(int ac, char **av)
   {
     gprtRayGenLaunch2D(gprt,rayGen,fbSize.x,fbSize.y);
 
-    gprtSwapBuffers(gprt);
+    gprtPresentBuffer(gprt, frameBuffer);
 
     // if (fbTexture == 0)
     //   glGenTextures(1, &fbTexture);

--- a/samples/int00-rayGenOnly/hostCode.cpp
+++ b/samples/int00-rayGenOnly/hostCode.cpp
@@ -39,13 +39,10 @@ extern GPRTProgram int00_deviceCode;
 
 // initial image resolution
 const int2 fbSize = {800,600};
-// GLuint fbTexture {0};
 
 #include <iostream>
 int main(int ac, char **av)
 {
-  getchar();
-  
   // The output window will show comments for many of the methods called.
   // Walking through the code line by line with a debugger is educational.
   LOG("gprt example '" << av[0] << "' starting up");
@@ -90,9 +87,7 @@ int main(int ac, char **av)
   // alloc buffers
   // ------------------------------------------------------------------
   LOG("allocating frame buffer");
-  // Create a frame buffer as page-locked, aka "pinned" memory.
-  // GPU writes to CPU memory directly (slow) but no transfers needed
-  GPRTBuffer frameBuffer = gprtHostBufferCreate(gprt,
+  GPRTBuffer frameBuffer = gprtDeviceBufferCreate(gprt,
                                           /*type:*/GPRT_INT,
                                           /*size:*/fbSize.x*fbSize.y);
 
@@ -108,16 +103,9 @@ int main(int ac, char **av)
 
 
   // ##################################################################
-  // create a window we can use to display and interact with the image
-  // ##################################################################
-
-  void* pixels = gprtBufferGetPointer(frameBuffer);
-
-  // ##################################################################
   // now that everything is ready: launch it ....
   // ##################################################################
   LOG("executing the launch ...");
-  // while (!glfwWindowShouldClose(window))
   while (!gprtWindowShouldClose(gprt))
   {
     gprtRayGenLaunch2D(gprt,rayGen,fbSize.x,fbSize.y);
@@ -127,9 +115,6 @@ int main(int ac, char **av)
   // ##################################################################
   // and finally, clean up
   // ##################################################################
-
-  // glfwDestroyWindow(window);
-  // glfwTerminate();
 
   LOG("cleaning up ...");
   gprtBufferDestroy(frameBuffer);

--- a/samples/int00-rayGenOnly/hostCode.cpp
+++ b/samples/int00-rayGenOnly/hostCode.cpp
@@ -44,6 +44,8 @@ const int2 fbSize = {800,600};
 #include <iostream>
 int main(int ac, char **av)
 {
+  getchar();
+  
   // The output window will show comments for many of the methods called.
   // Walking through the code line by line with a debugger is educational.
   LOG("gprt example '" << av[0] << "' starting up");
@@ -119,55 +121,7 @@ int main(int ac, char **av)
   while (!gprtWindowShouldClose(gprt))
   {
     gprtRayGenLaunch2D(gprt,rayGen,fbSize.x,fbSize.y);
-
     gprtPresentBuffer(gprt, frameBuffer);
-
-    // if (fbTexture == 0)
-    //   glGenTextures(1, &fbTexture);
-
-    // glBindTexture(GL_TEXTURE_2D, fbTexture);
-    // GLenum texFormat = GL_RGBA;
-    // GLenum texelType = GL_UNSIGNED_BYTE;
-    // glTexImage2D(GL_TEXTURE_2D, 0, texFormat, fbSize.x, fbSize.y, 0, GL_RGBA,
-    //               texelType, pixels);
-
-    // glDisable(GL_LIGHTING);
-    // glColor3f(1, 1, 1);
-
-    // glMatrixMode(GL_MODELVIEW);
-    // glLoadIdentity();
-
-    // glEnable(GL_TEXTURE_2D);
-    // glBindTexture(GL_TEXTURE_2D, fbTexture);
-    // glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    // glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-
-    // glDisable(GL_DEPTH_TEST);
-
-    // glViewport(0, 0, fbSize.x, fbSize.y);
-
-    // glMatrixMode(GL_PROJECTION);
-    // glLoadIdentity();
-    // glOrtho(0.f, (float)fbSize.x, 0.f, (float)fbSize.y, -1.f, 1.f);
-
-    // glBegin(GL_QUADS);
-    // {
-    //   glTexCoord2f(0.f, 0.f);
-    //   glVertex3f(0.f, 0.f, 0.f);
-
-    //   glTexCoord2f(0.f, 1.f);
-    //   glVertex3f(0.f, (float)fbSize.y, 0.f);
-
-    //   glTexCoord2f(1.f, 1.f);
-    //   glVertex3f((float)fbSize.x, (float)fbSize.y, 0.f);
-
-    //   glTexCoord2f(1.f, 0.f);
-    //   glVertex3f((float)fbSize.x, 0.f, 0.f);
-    // }
-    // glEnd();
-
-    // glfwSwapBuffers(window);
-    // glfwPollEvents();
   }
 
   // ##################################################################

--- a/samples/int00-rayGenOnly/hostCode.cpp
+++ b/samples/int00-rayGenOnly/hostCode.cpp
@@ -57,6 +57,9 @@ int main(int ac, char **av)
 
   LOG("building module, programs, and pipeline");
 
+  // Since we'll be using a window, we request support for an image swapchain
+  gprtRequestSwapchain();
+
   // Initialize Vulkan, and create a "gprt device," a context to hold the
   // ray generation shader and output buffer. The "1" is the number of devices requested.
   GPRTContext gprt = gprtContextCreate(nullptr, 1);

--- a/samples/int00-rayGenOnly/hostCode.cpp
+++ b/samples/int00-rayGenOnly/hostCode.cpp
@@ -26,9 +26,6 @@
 // our device-side data structures
 #include "deviceCode.h"
 
-// library for windowing
-#include <GLFW/glfw3.h>
-
 #define LOG(message)                                            \
   std::cout << GPRT_TERMINAL_BLUE;                               \
   std::cout << "#gprt.sample(main): " << message << std::endl;   \
@@ -42,7 +39,7 @@ extern GPRTProgram int00_deviceCode;
 
 // initial image resolution
 const int2 fbSize = {800,600};
-GLuint fbTexture {0};
+// GLuint fbTexture {0};
 
 #include <iostream>
 int main(int ac, char **av)
@@ -58,7 +55,7 @@ int main(int ac, char **av)
   LOG("building module, programs, and pipeline");
 
   // Since we'll be using a window, we request support for an image swapchain
-  gprtRequestSwapchain();
+  gprtRequestWindow(fbSize.x, fbSize.y, "Int00 Raygen Only");
 
   // Initialize Vulkan, and create a "gprt device," a context to hold the
   // ray generation shader and output buffer. The "1" is the number of devices requested.
@@ -111,25 +108,6 @@ int main(int ac, char **av)
   // ##################################################################
   // create a window we can use to display and interact with the image
   // ##################################################################
-  if (!glfwInit())
-    // Initialization failed
-    throw std::runtime_error("Can't initialize GLFW");
-
-  auto error_callback = [](int error, const char* description)
-  {
-    fprintf(stderr, "Error: %s\n", description);
-  };
-  glfwSetErrorCallback(error_callback);
-
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
-  glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
-  GLFWwindow* window = glfwCreateWindow(fbSize.x, fbSize.y, "Int00 Raygen Only",
-    NULL, NULL);
-  if (!window)
-    // Window or OpenGL context creation failed
-    throw std::runtime_error("Can't create window");
-  glfwMakeContextCurrent(window);
 
   void* pixels = gprtBufferGetPointer(frameBuffer);
 
@@ -137,64 +115,67 @@ int main(int ac, char **av)
   // now that everything is ready: launch it ....
   // ##################################################################
   LOG("executing the launch ...");
-  while (!glfwWindowShouldClose(window))
+  // while (!glfwWindowShouldClose(window))
+  while (!gprtWindowShouldClose(gprt))
   {
     gprtRayGenLaunch2D(gprt,rayGen,fbSize.x,fbSize.y);
 
-    if (fbTexture == 0)
-      glGenTextures(1, &fbTexture);
+    gprtSwapBuffers(gprt);
 
-    glBindTexture(GL_TEXTURE_2D, fbTexture);
-    GLenum texFormat = GL_RGBA;
-    GLenum texelType = GL_UNSIGNED_BYTE;
-    glTexImage2D(GL_TEXTURE_2D, 0, texFormat, fbSize.x, fbSize.y, 0, GL_RGBA,
-                  texelType, pixels);
+    // if (fbTexture == 0)
+    //   glGenTextures(1, &fbTexture);
 
-    glDisable(GL_LIGHTING);
-    glColor3f(1, 1, 1);
+    // glBindTexture(GL_TEXTURE_2D, fbTexture);
+    // GLenum texFormat = GL_RGBA;
+    // GLenum texelType = GL_UNSIGNED_BYTE;
+    // glTexImage2D(GL_TEXTURE_2D, 0, texFormat, fbSize.x, fbSize.y, 0, GL_RGBA,
+    //               texelType, pixels);
 
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
+    // glDisable(GL_LIGHTING);
+    // glColor3f(1, 1, 1);
 
-    glEnable(GL_TEXTURE_2D);
-    glBindTexture(GL_TEXTURE_2D, fbTexture);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    // glMatrixMode(GL_MODELVIEW);
+    // glLoadIdentity();
 
-    glDisable(GL_DEPTH_TEST);
+    // glEnable(GL_TEXTURE_2D);
+    // glBindTexture(GL_TEXTURE_2D, fbTexture);
+    // glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    // glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
-    glViewport(0, 0, fbSize.x, fbSize.y);
+    // glDisable(GL_DEPTH_TEST);
 
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-    glOrtho(0.f, (float)fbSize.x, 0.f, (float)fbSize.y, -1.f, 1.f);
+    // glViewport(0, 0, fbSize.x, fbSize.y);
 
-    glBegin(GL_QUADS);
-    {
-      glTexCoord2f(0.f, 0.f);
-      glVertex3f(0.f, 0.f, 0.f);
+    // glMatrixMode(GL_PROJECTION);
+    // glLoadIdentity();
+    // glOrtho(0.f, (float)fbSize.x, 0.f, (float)fbSize.y, -1.f, 1.f);
 
-      glTexCoord2f(0.f, 1.f);
-      glVertex3f(0.f, (float)fbSize.y, 0.f);
+    // glBegin(GL_QUADS);
+    // {
+    //   glTexCoord2f(0.f, 0.f);
+    //   glVertex3f(0.f, 0.f, 0.f);
 
-      glTexCoord2f(1.f, 1.f);
-      glVertex3f((float)fbSize.x, (float)fbSize.y, 0.f);
+    //   glTexCoord2f(0.f, 1.f);
+    //   glVertex3f(0.f, (float)fbSize.y, 0.f);
 
-      glTexCoord2f(1.f, 0.f);
-      glVertex3f((float)fbSize.x, 0.f, 0.f);
-    }
-    glEnd();
+    //   glTexCoord2f(1.f, 1.f);
+    //   glVertex3f((float)fbSize.x, (float)fbSize.y, 0.f);
 
-    glfwSwapBuffers(window);
-    glfwPollEvents();
+    //   glTexCoord2f(1.f, 0.f);
+    //   glVertex3f((float)fbSize.x, 0.f, 0.f);
+    // }
+    // glEnd();
+
+    // glfwSwapBuffers(window);
+    // glfwPollEvents();
   }
 
   // ##################################################################
   // and finally, clean up
   // ##################################################################
 
-  glfwDestroyWindow(window);
-  glfwTerminate();
+  // glfwDestroyWindow(window);
+  // glfwTerminate();
 
   LOG("cleaning up ...");
   gprtBufferDestroy(frameBuffer);


### PR DESCRIPTION
With nsight graphics, we need to support an official Vulkan swapchain in order to profile our kernels. 

Additionally, swapchains allow us to directly render images on the GPU without using OpenGL and a host-pinned buffer to transfer the framebuffer through PCIE.

Down the road, I hope to use this change to simplify how we write our samples. See the changes made to int00-rayGenOnly to get a sense for how things might get simpler. 

Solves issue #36 