### PR TITLE
Adding option for checking out submodules automatically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,24 @@ if (GPRT_IS_SUBPROJECT)
 endif()
 set(GPRT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gprt)
 
+#===============================================================================
+# Update git submodules as needed
+#===============================================================================
+
+find_package(Git)
+if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+  option(GIT_SUBMODULE "Check submodules during build" ON)
+  if(GIT_SUBMODULE)
+    message(STATUS "Submodule update")
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    RESULT_VARIABLE GIT_SUBMOD_RESULT)
+    if(NOT GIT_SUBMOD_RESULT EQUAL 0)
+      message(FATAL_ERROR "git submodule update --init failed with \
+        ${GIT_SUBMOD_RESULT}, please checkout submodules")
+    endif()
+  endif()
+endif()
 
 # ------------------------------------------------------------------
 # first, include some dependencies


### PR DESCRIPTION
This adds an option to automatically clone submodules during the CMake configuration step. It can be turned on and off using the CMake variable `GIT_SUBMODULE` (default is on) in case development work is going on in one of the submodules.