### PR TITLE
Move to official compute kernel entry points

### DIFF
--- a/samples/s04-computeAABBs/deviceCode.hlsl
+++ b/samples/s04-computeAABBs/deviceCode.hlsl
@@ -65,7 +65,7 @@ GPRT_CLOSEST_HIT_PROGRAM(SphereClosestHit, (SphereGeomData, record), (Payload, p
   payload.color = abs(normal);
 }
 
-GPRT_COMPUTE_PROGRAM(SphereBounds, (SphereBoundsData, record)) {
+GPRT_COMPUTE_PROGRAM(SphereBounds, (SphereBoundsData, record), (1, 1, 1)) {
   int primID = DispatchThreadID.x;
   float3 position = gprt::load<float3>(record.vertex, primID);
   float radius = gprt::load<float>(record.radius, primID);

--- a/samples/s04-computeAABBs/hostCode.cpp
+++ b/samples/s04-computeAABBs/hostCode.cpp
@@ -259,6 +259,7 @@ main(int ac, char **av) {
   gprtBufferDestroy(frameBuffer);
   gprtRayGenDestroy(rayGen);
   gprtMissDestroy(miss);
+  gprtComputeDestroy(boundsProgram);
   gprtAccelDestroy(aabbAccel);
   gprtAccelDestroy(world);
   gprtGeomDestroy(aabbGeom);

--- a/samples/s04-computeAABBs/sharedCode.h
+++ b/samples/s04-computeAABBs/sharedCode.h
@@ -33,6 +33,15 @@ struct SphereBoundsData {
   alignas(16) gprt::Buffer aabbs;
 };
 
+struct SphereBoundsData2 {
+  /*! array/buffer of vertex indices */
+  alignas(16) gprt::Buffer vertex;   // vec3f*
+  /*! array/buffer of vertex positions */
+  alignas(16) gprt::Buffer radius;   // float *
+  /*! array/buffer of AABBs */
+  alignas(16) gprt::Buffer aabbs;
+};
+
 /* variables for the triangle mesh geometry */
 struct SphereGeomData {
   /*! array/buffer of vertex indices */

--- a/samples/s05-computeVertex/deviceCode.hlsl
+++ b/samples/s05-computeVertex/deviceCode.hlsl
@@ -31,7 +31,7 @@ getPos(float px, float py, float k, float width, float depth, float height, floa
   return float3(x * width, y * depth, z * height + zoffset);
 }
 
-GPRT_COMPUTE_PROGRAM(Vertex, (TrianglesGeomData, record)) {
+GPRT_COMPUTE_PROGRAM(Vertex, (TrianglesGeomData, record), (1, 1, 1)) {
   uint gridSize = record.gridSize;
   int TriID = DispatchThreadID.x;
   float now = record.now;

--- a/samples/s06-computeTransform/deviceCode.hlsl
+++ b/samples/s06-computeTransform/deviceCode.hlsl
@@ -22,7 +22,7 @@
 
 #include "sharedCode.h"
 
-GPRT_COMPUTE_PROGRAM(Transform, (TransformData, record)) {
+GPRT_COMPUTE_PROGRAM(Transform, (TransformData, record), (1, 1, 1)) {
   int numTransforms = record.numTransforms;
   int length = sqrt(numTransforms);
 

--- a/samples/s08-singleTexture/deviceCode.hlsl
+++ b/samples/s08-singleTexture/deviceCode.hlsl
@@ -41,7 +41,7 @@ AngleAxis3x3(float angle, float3 axis) {
                   t * y * z - s * x, t * x * z - s * y, t * y * z + s * x, t * z * z + c);
 }
 
-GPRT_COMPUTE_PROGRAM(Transform, (TransformData, record)) {
+GPRT_COMPUTE_PROGRAM(Transform, (TransformData, record), (1, 1, 1)) {
   // This kernel animates the texture planes, rotating them in a circle
   // and placing them in a grid.
   int transformID = DispatchThreadID.x;

--- a/samples/s10-rasterization/CMakeLists.txt
+++ b/samples/s10-rasterization/CMakeLists.txt
@@ -22,14 +22,14 @@
 
 embed_devicecode(
   OUTPUT_TARGET
-    t01_deviceCode
+    s10_deviceCode
   SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/deviceCode.hlsl
 )
 
-add_executable(t01_raster hostCode.cpp)
-target_link_libraries(t01_raster
+add_executable(s10_raster hostCode.cpp)
+target_link_libraries(s10_raster
   PRIVATE
-    t01_deviceCode
+    s10_deviceCode
     gprt::gprt
 )

--- a/samples/s10-rasterization/hostCode.cpp
+++ b/samples/s10-rasterization/hostCode.cpp
@@ -38,7 +38,7 @@
   std::cout << "#gprt.sample(main): " << message << std::endl;                                                         \
   std::cout << GPRT_TERMINAL_DEFAULT;
 
-extern GPRTProgram t01_deviceCode;
+extern GPRTProgram s10_deviceCode;
 
 // Vertices are the points that define our triangles
 const int NUM_TRI_VERTICES = 3;
@@ -76,7 +76,7 @@ int3 backdropIndices[NUM_BACKDROP_INDICES] = {{0, 1, 2}, {1, 3, 2}};
 const int2 fbSize = {1400, 460};
 
 // final image output
-const char *outFileName = "t01-singleTriangle.png";
+const char *outFileName = "s10-rasterization.png";
 
 // Initial camera parameters
 float3 lookFrom = {0.f, 0.f, -4.f};
@@ -92,9 +92,9 @@ main(int ac, char **av) {
   LOG("building module, programs, and pipeline");
 
   // create a context on the first device:
-  gprtRequestWindow(fbSize.x, fbSize.y, "S01 Single Triangle");
+  gprtRequestWindow(fbSize.x, fbSize.y, "S10 Rasterization");
   GPRTContext context = gprtContextCreate();
-  GPRTModule module = gprtModuleCreate(context, t01_deviceCode);
+  GPRTModule module = gprtModuleCreate(context, s10_deviceCode);
 
   // ##################################################################
   // set up all the GPU kernels we want to run


### PR DESCRIPTION
Previously, we were using ray generation programs under the hood in place of compute kernels. Although that works for many simple compute kernels, for more advanced compute kernels where shuffle and synchronization operations are required, that doesn't work.

This PR moves us over to using official HLSL compute kernel entry points. This should allow us to take advantage of things like shared memory and compute kernel specific intrinsics. 

Down the road, this will be helpful if ever we need to have GPU-parallel sorting operations, tree construction, etc...