### PR TITLE
Push constants

### DIFF
--- a/gprt/gprt.hlsl
+++ b/gprt/gprt.hlsl
@@ -29,6 +29,11 @@ typedef struct VkAccelerationStructureInstanceKHR {
 }
 VkAccelerationStructureInstanceKHR;
 
+struct PushConstants {
+  uint64_t r[16];
+};
+[[vk::push_constant]] PushConstants pc;
+
 [shader("compute")]
 [numthreads(1, 1, 1)]
 void

--- a/gprt/gprt_device.h
+++ b/gprt/gprt_device.h
@@ -31,10 +31,10 @@
 
 #define alignas(alignment)
 
-struct PushConstants {
-  uint64_t r[16];
-};
-[[vk::push_constant]] PushConstants pc;
+// struct PushConstants {
+//   uint64_t r[16];
+// };
+// [[vk::push_constant]] PushConstants pc;
 
 // Descriptor binding, then set number.
 // Currently, 0, N is used for textures
@@ -187,11 +187,6 @@ getDefaultSampler() {
   return samplers[0];
 }
 
-uint32_t
-getNumRayTypes() {
-  // for now, we map PC 0 to ray type count
-  return uint32_t(pc.r[0]);
-}
 };   // namespace gprt
 
 /*

--- a/gprt/gprt_host.h
+++ b/gprt/gprt_host.h
@@ -335,7 +335,8 @@ gprtTrianglesSetIndices(GPRTGeomOf<T1> triangles, GPRTBufferOf<T2> indices, uint
   for the given AABB geometry. This _has_ to be set before the accel(s)
   that this geom is used in get built. */
 GPRT_API void gprtAABBsSetPositions(GPRTGeom aabbs, GPRTBuffer positions, uint32_t count,
-                                    uint32_t stride GPRT_IF_CPP(= 2 * sizeof(float3)), uint32_t offset GPRT_IF_CPP(= 0));
+                                    uint32_t stride GPRT_IF_CPP(= 2 * sizeof(float3)),
+                                    uint32_t offset GPRT_IF_CPP(= 0));
 
 template <typename T1, typename T2>
 void
@@ -1198,14 +1199,39 @@ gprtGeomTypeSetRasterAttachments(GPRTGeomTypeOf<T1> type, int rasterType, GPRTTe
                                    (GPRTTexture) depthAttachment);
 }
 
+/**
+ * @brief Rasterize a list of GPRT geometry. (Currently assuming all geometry are GPRT_TRIANGLES)
+ * 
+ * @param context The GPRT context used to rasterize the triangles
+ * @param geomType The geometry type to fetch raster programs from
+ * @param numGeometry The number of GPRTGeoms to rasterize
+ * @param geometry A pointer to a list of GPRT geometry, to be rasterized in the order given
+ * @param rasterType Controls which rasterization programs to use. Analogous to "Ray Type", in 
+ * that it indexes into the shader binding table.
+ * @param instanceCounts How many instances of each geometry in the "geometry" list to rasterize. 
+ * Useful for rasterizing the same geometry in many different locations. If null pointer, this parameter is ignored.
+ * Otherwise, we expect a list of length "numGeometry"
+ * @param pushConstantsSize The size of the push constants structure to upload to the device. 
+ * If 0, no push constants are updated. Currently limited to 128 bytes or less.
+ * @param pushConstants A pointer to a structure of push constants to upload to the device.
+*/
 void gprtGeomTypeRasterize(GPRTContext context, GPRTGeomType geomType, uint32_t numGeometry, GPRTGeom *geometry,
-                           uint32_t rasterType = 0, uint32_t *instanceCounts = nullptr);
+                           uint32_t rasterType, uint32_t *instanceCounts,
+                           size_t pushConstantsSize GPRT_IF_CPP(= 0), 
+                            void *pushConstants GPRT_IF_CPP(= 0));
 
-template <typename T>
+template <typename RecordType>
 void
-gprtGeomTypeRasterize(GPRTContext context, GPRTGeomTypeOf<T> geomType, uint32_t numGeometry, GPRTGeomOf<T> *geometry,
-                      uint32_t rayType = 0, uint32_t *instanceCounts = nullptr) {
+gprtGeomTypeRasterize(GPRTContext context, GPRTGeomTypeOf<RecordType> geomType, uint32_t numGeometry, GPRTGeomOf<RecordType> *geometry,
+                      uint32_t rayType, uint32_t *instanceCounts) {
   gprtGeomTypeRasterize(context, (GPRTGeomType) geomType, numGeometry, (GPRTGeom *) geometry, rayType, instanceCounts);
+}
+
+template <typename RecordType, typename PushConstantsType>
+void
+gprtGeomTypeRasterize(GPRTContext context, GPRTGeomTypeOf<RecordType> geomType, uint32_t numGeometry, GPRTGeomOf<RecordType> *geometry,
+                      uint32_t rayType, uint32_t *instanceCounts, PushConstantsType pc) {
+  gprtGeomTypeRasterize(context, (GPRTGeomType) geomType, numGeometry, (GPRTGeom *) geometry, rayType, instanceCounts, sizeof(PushConstantsType), &pc);
 }
 
 /**
@@ -1593,9 +1619,9 @@ GPRT_API void gprtBufferTextureCopy(GPRTContext context, GPRTBuffer buffer, GPRT
 template <typename T1, typename T2>
 void
 gprtBufferTextureCopy(GPRTContext context, GPRTBufferOf<T1> buffer, GPRTTextureOf<T2> texture, uint32_t bufferOffset,
-                      uint32_t bufferRowLength, uint32_t bufferImageHeight, uint32_t imageOffsetX, uint32_t imageOffsetY,
-                      uint32_t imageOffsetZ, uint32_t imageExtentX, uint32_t imageExtentY, uint32_t imageExtentZ,
-                      int srcDeviceID GPRT_IF_CPP(= 0), int dstDeviceID GPRT_IF_CPP(= 0)) {
+                      uint32_t bufferRowLength, uint32_t bufferImageHeight, uint32_t imageOffsetX,
+                      uint32_t imageOffsetY, uint32_t imageOffsetZ, uint32_t imageExtentX, uint32_t imageExtentY,
+                      uint32_t imageExtentZ, int srcDeviceID GPRT_IF_CPP(= 0), int dstDeviceID GPRT_IF_CPP(= 0)) {
   gprtBufferTextureCopy(context, (GPRTBuffer) buffer, (GPRTTexture) texture, bufferOffset, bufferRowLength,
                         bufferImageHeight, imageOffsetX, imageOffsetY, imageOffsetZ, imageExtentX, imageExtentY,
                         imageExtentZ, srcDeviceID, dstDeviceID);
@@ -1702,57 +1728,111 @@ gprtBufferSaveImage(GPRTBufferOf<T> buffer, uint32_t width, uint32_t height, con
   gprtBufferSaveImage((GPRTBuffer) buffer, width, height, imageName);
 }
 
-GPRT_API void gprtRayGenLaunch1D(GPRTContext context, GPRTRayGen rayGen, uint32_t dims_x);
+GPRT_API void gprtRayGenLaunch1D(GPRTContext context, GPRTRayGen rayGen, uint32_t dims_x,
+                                 size_t pushConstantsSize GPRT_IF_CPP(= 0), void *pushConstants GPRT_IF_CPP(= 0));
 
-template <typename T>
+template <typename RecordType>
 void
-gprtRayGenLaunch1D(GPRTContext context, GPRTRayGenOf<T> rayGen, uint32_t dims_x) {
+gprtRayGenLaunch1D(GPRTContext context, GPRTRayGenOf<RecordType> rayGen, uint32_t dims_x) {
   gprtRayGenLaunch1D(context, (GPRTRayGen) rayGen, dims_x);
+}
+
+template <typename RecordType, typename PushConstantsType>
+void
+gprtRayGenLaunch1D(GPRTContext context, GPRTRayGenOf<RecordType> rayGen, uint32_t dims_x, PushConstantsType pushConstants) {
+  static_assert(sizeof(PushConstantsType) <= 128, "Current GPRT push constant size limited to 128 bytes or less");
+  gprtRayGenLaunch1D(context, (GPRTRayGen) rayGen, dims_x, sizeof(PushConstantsType), &pushConstants);
 }
 
 /*! Executes a ray tracing pipeline with the given raygen program.
   This call will block until the raygen program returns. */
-GPRT_API void gprtRayGenLaunch2D(GPRTContext context, GPRTRayGen rayGen, uint32_t dims_x, uint32_t dims_y);
+GPRT_API void gprtRayGenLaunch2D(GPRTContext context, GPRTRayGen rayGen, uint32_t dims_x, uint32_t dims_y,
+                                 size_t pushConstantsSize GPRT_IF_CPP(= 0), void *pushConstants GPRT_IF_CPP(= 0));
 
-template <typename T>
+template <typename RecordType>
 void
-gprtRayGenLaunch2D(GPRTContext context, GPRTRayGenOf<T> rayGen, uint32_t dims_x, uint32_t dims_y) {
+gprtRayGenLaunch2D(GPRTContext context, GPRTRayGenOf<RecordType> rayGen, uint32_t dims_x, uint32_t dims_y) {
   gprtRayGenLaunch2D(context, (GPRTRayGen) rayGen, dims_x, dims_y);
 }
 
-/*! 3D-launch variant of \see gprtRayGenLaunch2D */
-GPRT_API void gprtRayGenLaunch3D(GPRTContext context, GPRTRayGen rayGen, uint32_t dims_x, uint32_t dims_y, uint32_t dims_z);
-
-template <typename T>
+template <typename RecordType, typename PushConstantsType>
 void
-gprtRayGenLaunch3D(GPRTContext context, GPRTRayGenOf<T> rayGen, uint32_t dims_x, uint32_t dims_y, uint32_t dims_z) {
+gprtRayGenLaunch2D(GPRTContext context, GPRTRayGenOf<RecordType> rayGen, uint32_t dims_x, uint32_t dims_y, PushConstantsType pushConstants) {
+  static_assert(sizeof(PushConstantsType) <= 128, "Current GPRT push constant size limited to 128 bytes or less");
+  gprtRayGenLaunch2D(context, (GPRTRayGen) rayGen, dims_x, dims_y, sizeof(PushConstantsType), &pushConstants);
+}
+
+/*! 3D-launch variant of \see gprtRayGenLaunch2D */
+GPRT_API void gprtRayGenLaunch3D(GPRTContext context, GPRTRayGen rayGen, uint32_t dims_x, uint32_t dims_y,
+                                 uint32_t dims_z, size_t pushConstantsSize GPRT_IF_CPP(= 0),
+                                 void *pushConstants GPRT_IF_CPP(= 0));
+
+template <typename RecordType>
+void
+gprtRayGenLaunch3D(GPRTContext context, GPRTRayGenOf<RecordType> rayGen, uint32_t dims_x, uint32_t dims_y, uint32_t dims_z) {
   gprtRayGenLaunch3D(context, (GPRTRayGen) rayGen, dims_x, dims_y, dims_z);
 }
 
-GPRT_API void gprtComputeLaunch1D(GPRTContext context, GPRTCompute compute, uint32_t x_workgroups);
-
-template <typename T>
+template <typename RecordType, typename PushConstantsType>
 void
-gprtComputeLaunch1D(GPRTContext context, GPRTComputeOf<T> compute, uint32_t x_workgroups) {
+gprtRayGenLaunch3D(GPRTContext context, GPRTRayGenOf<RecordType> rayGen, uint32_t dims_x, uint32_t dims_y, uint32_t dims_z, PushConstantsType pushConstants) {
+  static_assert(sizeof(PushConstantsType) <= 128, "Current GPRT push constant size limited to 128 bytes or less");
+  gprtRayGenLaunch3D(context, (GPRTRayGen) rayGen, dims_x, dims_y, dims_z, sizeof(PushConstantsType), &pushConstants);
+}
+
+GPRT_API void gprtComputeLaunch1D(GPRTContext context, GPRTCompute compute, uint32_t x_workgroups, 
+                                  size_t pushConstantsSize GPRT_IF_CPP(= 0), 
+                                  void *pushConstants GPRT_IF_CPP(= 0));
+
+template <typename RecordType>
+void
+gprtComputeLaunch1D(GPRTContext context, GPRTComputeOf<RecordType> compute, uint32_t x_workgroups) {
   gprtComputeLaunch1D(context, (GPRTCompute) compute, x_workgroups);
 }
 
-GPRT_API void gprtComputeLaunch2D(GPRTContext context, GPRTCompute compute, uint32_t x_workgroups, uint32_t y_workgroups);
-
-template <typename T>
+template <typename RecordType, typename PushConstantsType>
 void
-gprtComputeLaunch2D(GPRTContext context, GPRTComputeOf<T> compute, uint32_t x_workgroups, uint32_t y_workgroups) {
+gprtComputeLaunch1D(GPRTContext context, GPRTComputeOf<RecordType> compute, uint32_t x_workgroups, PushConstantsType pushConstants) {
+  static_assert(sizeof(PushConstantsType) <= 128, "Current GPRT push constant size limited to 128 bytes or less");
+  gprtComputeLaunch1D(context, (GPRTCompute) compute, x_workgroups, sizeof(PushConstantsType), &pushConstants);
+}
+
+GPRT_API void gprtComputeLaunch2D(GPRTContext context, GPRTCompute compute, uint32_t x_workgroups,
+                                  uint32_t y_workgroups,
+                                  size_t pushConstantsSize GPRT_IF_CPP(= 0), 
+                                  void *pushConstants GPRT_IF_CPP(= 0));
+
+template <typename RecordType>
+void
+gprtComputeLaunch2D(GPRTContext context, GPRTComputeOf<RecordType> compute, uint32_t x_workgroups, uint32_t y_workgroups) {
   gprtComputeLaunch2D(context, (GPRTCompute) compute, x_workgroups, y_workgroups);
 }
 
-GPRT_API void gprtComputeLaunch3D(GPRTContext context, GPRTCompute compute, uint32_t x_workgroups, uint32_t y_workgroups,
-                                  uint32_t z_workgroups);
-
-template <typename T>
+template <typename RecordType, typename PushConstantsType>
 void
-gprtComputeLaunch3D(GPRTContext context, GPRTComputeOf<T> compute, uint32_t x_workgroups, uint32_t y_workgroups,
+gprtComputeLaunch2D(GPRTContext context, GPRTComputeOf<RecordType> compute, uint32_t x_workgroups, uint32_t y_workgroups, PushConstantsType pushConstants) {
+  static_assert(sizeof(PushConstantsType) <= 128, "Current GPRT push constant size limited to 128 bytes or less");
+  gprtComputeLaunch2D(context, (GPRTCompute) compute, x_workgroups, y_workgroups, sizeof(PushConstantsType), &pushConstants);
+}
+
+GPRT_API void gprtComputeLaunch3D(GPRTContext context, GPRTCompute compute, uint32_t x_workgroups,
+                                  uint32_t y_workgroups, uint32_t z_workgroups, 
+                                  size_t pushConstantsSize GPRT_IF_CPP(= 0), 
+                                  void *pushConstants GPRT_IF_CPP(= 0));
+
+template <typename RecordType>
+void
+gprtComputeLaunch3D(GPRTContext context, GPRTComputeOf<RecordType> compute, uint32_t x_workgroups, uint32_t y_workgroups,
                     uint32_t z_workgroups) {
   gprtComputeLaunch3D(context, (GPRTCompute) compute, x_workgroups, y_workgroups, z_workgroups);
+}
+
+template <typename RecordType, typename PushConstantsType>
+void
+gprtComputeLaunch3D(GPRTContext context, GPRTComputeOf<RecordType> compute, uint32_t x_workgroups, uint32_t y_workgroups,
+                    uint32_t z_workgroups, PushConstantsType pushConstants) {
+  static_assert(sizeof(PushConstantsType) <= 128, "Current GPRT push constant size limited to 128 bytes or less");
+  gprtComputeLaunch3D(context, (GPRTCompute) compute, x_workgroups, y_workgroups, z_workgroups, sizeof(PushConstantsType), &pushConstants);
 }
 
 GPRT_API void gprtBeginProfile(GPRTContext context);

--- a/samples/s01-singleTriangle/deviceCode.hlsl
+++ b/samples/s01-singleTriangle/deviceCode.hlsl
@@ -22,6 +22,8 @@
 
 #include "sharedCode.h"
 
+[[vk::push_constant]] PushConstants pc;
+
 struct [raypayload] Payload {
   float3 color : read(caller) : write(closesthit, miss);
 };
@@ -40,9 +42,9 @@ GPRT_RAYGEN_PROGRAM(simpleRayGen, (RayGenData, record)) {
   float2 screen = (float2(pixelID) + float2(.5f, .5f)) / float2(fbSize);
 
   RayDesc rayDesc;
-  rayDesc.Origin = record.camera.pos;
+  rayDesc.Origin = pc.camera.pos;
   rayDesc.Direction =
-      normalize(record.camera.dir_00 + screen.x * record.camera.dir_du + screen.y * record.camera.dir_dv);
+      normalize(pc.camera.dir_00 + screen.x * pc.camera.dir_du + screen.y * pc.camera.dir_dv);
   rayDesc.TMin = 0.001;
   rayDesc.TMax = 10000.0;
   RaytracingAccelerationStructure world = gprt::getAccelHandle(record.world);

--- a/samples/s01-singleTriangle/hostCode.cpp
+++ b/samples/s01-singleTriangle/hostCode.cpp
@@ -160,6 +160,10 @@ main(int ac, char **av) {
 
   LOG("launching ...");
 
+  // Structure of parameters that change each frame. We can edit these 
+  // without rebuilding the shader binding table.
+  PushConstants pc;
+
   bool firstFrame = true;
   double xpos = 0.f, ypos = 0.f;
   double lastxpos, lastypos;
@@ -209,18 +213,14 @@ main(int ac, char **av) {
       camera_d00 -= 0.5f * camera_ddv;
 
       // ----------- set variables  ----------------------------
-      RayGenData *raygenData = gprtRayGenGetParameters(rayGen);
-      raygenData->camera.pos = camera_pos;
-      raygenData->camera.dir_00 = camera_d00;
-      raygenData->camera.dir_du = camera_ddu;
-      raygenData->camera.dir_dv = camera_ddv;
-
-      // Use this to upload all set parameters to our ray tracing device
-      gprtBuildShaderBindingTable(context, GPRT_SBT_RAYGEN);
+      pc.camera.pos = camera_pos;
+      pc.camera.dir_00 = camera_d00;
+      pc.camera.dir_du = camera_ddu;
+      pc.camera.dir_dv = camera_ddv;
     }
 
     // Calls the GPU raygen kernel function
-    gprtRayGenLaunch2D(context, rayGen, fbSize.x, fbSize.y);
+    gprtRayGenLaunch2D(context, rayGen, fbSize.x, fbSize.y, pc);
 
     // If a window exists, presents the framebuffer here to that window
     gprtBufferPresent(context, frameBuffer);

--- a/samples/s01-singleTriangle/sharedCode.h
+++ b/samples/s01-singleTriangle/sharedCode.h
@@ -31,19 +31,22 @@ struct TrianglesGeomData {
 
 struct RayGenData {
   alignas(16) gprt::Buffer frameBuffer;
-
   alignas(16) gprt::Accel world;
-
-  struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
-  } camera;
 };
 
 /* variables for the miss program */
 struct MissProgData {
   alignas(16) float3 color0;
   alignas(16) float3 color1;
+};
+
+/* A small structure of constants that can change every frame without rebuilding the 
+  shader binding table. (must be 128 bytes or less) */
+struct PushConstants {
+  struct {
+    alignas(16) float3 pos;
+    alignas(16) float3 dir_00;
+    alignas(16) float3 dir_du;
+    alignas(16) float3 dir_dv;
+  } camera;
 };

--- a/samples/s02-instances/deviceCode.hlsl
+++ b/samples/s02-instances/deviceCode.hlsl
@@ -22,6 +22,8 @@
 
 #include "sharedCode.h"
 
+[[vk::push_constant]] PushConstants pc;
+
 struct [raypayload] Payload {
   float3 color : read(caller) : write(closesthit, miss);
 };
@@ -35,9 +37,9 @@ GPRT_RAYGEN_PROGRAM(simpleRayGen, (RayGenData, record)) {
   float2 screen = (float2(pixelID) + float2(.5f, .5f)) / float2(fbSize);
 
   RayDesc rayDesc;
-  rayDesc.Origin = record.camera.pos;
+  rayDesc.Origin = pc.camera.pos;
   rayDesc.Direction =
-      normalize(record.camera.dir_00 + screen.x * record.camera.dir_du + screen.y * record.camera.dir_dv);
+      normalize(pc.camera.dir_00 + screen.x * pc.camera.dir_du + screen.y * pc.camera.dir_dv);
   rayDesc.TMin = 0.001;
   rayDesc.TMax = 10000.0;
   RaytracingAccelerationStructure world = gprt::getAccelHandle(record.world);

--- a/samples/s02-instances/hostCode.cpp
+++ b/samples/s02-instances/hostCode.cpp
@@ -167,6 +167,10 @@ main(int ac, char **av) {
   // now that everything is ready: launch it ....
   // ##################################################################
 
+  // Structure of parameters that change each frame. We can edit these 
+  // without rebuilding the shader binding table.
+  PushConstants pc;
+
   LOG("launching ...");
 
   bool firstFrame = true;
@@ -209,27 +213,17 @@ main(int ac, char **av) {
       lookFrom = ((mul(rotationMatrixY, (position - pivot))) + pivot).xyz();
 
       // ----------- compute variable values  ------------------
-      float3 camera_pos = lookFrom;
-      float3 camera_d00 = normalize(lookAt - lookFrom);
+      pc.camera.pos = lookFrom;
+      pc.camera.dir_00 = normalize(lookAt - lookFrom);
       float aspect = float(fbSize.x) / float(fbSize.y);
-      float3 camera_ddu = cosFovy * aspect * normalize(cross(camera_d00, lookUp));
-      float3 camera_ddv = cosFovy * normalize(cross(camera_ddu, camera_d00));
-      camera_d00 -= 0.5f * camera_ddu;
-      camera_d00 -= 0.5f * camera_ddv;
-
-      // ----------- set variables  ----------------------------
-      RayGenData *raygenData = gprtRayGenGetParameters(rayGen);
-      raygenData->camera.pos = camera_pos;
-      raygenData->camera.dir_00 = camera_d00;
-      raygenData->camera.dir_du = camera_ddu;
-      raygenData->camera.dir_dv = camera_ddv;
-
-      // Use this to upload all set parameters to our ray tracing device
-      gprtBuildShaderBindingTable(context, GPRT_SBT_RAYGEN);
+      pc.camera.dir_du = cosFovy * aspect * normalize(cross(pc.camera.dir_00, lookUp));
+      pc.camera.dir_dv = cosFovy * normalize(cross(pc.camera.dir_du, pc.camera.dir_00));
+      pc.camera.dir_00 -= 0.5f * pc.camera.dir_du;
+      pc.camera.dir_00 -= 0.5f * pc.camera.dir_dv;
     }
 
     // Calls the GPU raygen kernel function
-    gprtRayGenLaunch2D(context, rayGen, fbSize.x, fbSize.y);
+    gprtRayGenLaunch2D(context, rayGen, fbSize.x, fbSize.y, pc);
 
     // If a window exists, presents the framebuffer here to that window
     gprtBufferPresent(context, frameBuffer);

--- a/samples/s02-instances/sharedCode.h
+++ b/samples/s02-instances/sharedCode.h
@@ -34,19 +34,21 @@ struct TrianglesGeomData {
 
 struct RayGenData {
   alignas(16) gprt::Buffer frameBuffer;
-
   alignas(16) gprt::Accel world;
-
-  struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
-  } camera;
 };
 
 /* variables for the miss program */
 struct MissProgData {
   alignas(16) float3 color0;
   alignas(16) float3 color1;
+};
+
+/* Constants that change each frame */
+struct PushConstants {
+  struct {
+    alignas(16) float3 pos;
+    alignas(16) float3 dir_00;
+    alignas(16) float3 dir_du;
+    alignas(16) float3 dir_dv;
+  } camera;
 };

--- a/samples/s03-singleAABB/deviceCode.hlsl
+++ b/samples/s03-singleAABB/deviceCode.hlsl
@@ -22,6 +22,8 @@
 
 #include "sharedCode.h"
 
+[[vk::push_constant]] PushConstants pc;
+
 struct [raypayload] Payload {
   float3 color : read(caller) : write(closesthit, miss);
 };
@@ -35,9 +37,9 @@ GPRT_RAYGEN_PROGRAM(simpleRayGen, (RayGenData, record)) {
   float2 screen = (float2(pixelID) + float2(.5f, .5f)) / float2(fbSize);
 
   RayDesc rayDesc;
-  rayDesc.Origin = record.camera.pos;
+  rayDesc.Origin = pc.camera.pos;
   rayDesc.Direction =
-      normalize(record.camera.dir_00 + screen.x * record.camera.dir_du + screen.y * record.camera.dir_dv);
+      normalize(pc.camera.dir_00 + screen.x * pc.camera.dir_du + screen.y * pc.camera.dir_dv);
   rayDesc.TMin = 0.0;
   rayDesc.TMax = 10000.0;
   RaytracingAccelerationStructure world = gprt::getAccelHandle(record.world);

--- a/samples/s03-singleAABB/sharedCode.h
+++ b/samples/s03-singleAABB/sharedCode.h
@@ -31,19 +31,21 @@ struct AABBGeomData {
 
 struct RayGenData {
   alignas(16) gprt::Buffer frameBuffer;
-
   alignas(16) gprt::Accel world;
-
-  struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
-  } camera;
 };
 
 /* variables for the miss program */
 struct MissProgData {
   alignas(16) float3 color0;
   alignas(16) float3 color1;
+};
+
+/* Constants that change each frame */
+struct PushConstants {
+  struct {
+    alignas(16) float3 pos;
+    alignas(16) float3 dir_00;
+    alignas(16) float3 dir_du;
+    alignas(16) float3 dir_dv;
+  } camera;
 };

--- a/samples/s04-computeAABBs/deviceCode.hlsl
+++ b/samples/s04-computeAABBs/deviceCode.hlsl
@@ -22,6 +22,8 @@
 
 #include "sharedCode.h"
 
+[[vk::push_constant]] PushConstants pc;
+
 struct [raypayload] Payload {
   float3 color : read(caller) : write(closesthit, miss);
 };
@@ -33,9 +35,9 @@ GPRT_RAYGEN_PROGRAM(simpleRayGen, (RayGenData, record)) {
   float2 screen = (float2(pixelID) + float2(.5f, .5f)) / float2(fbSize);
 
   RayDesc rayDesc;
-  rayDesc.Origin = record.camera.pos;
+  rayDesc.Origin = pc.camera.pos;
   rayDesc.Direction =
-      normalize(record.camera.dir_00 + screen.x * record.camera.dir_du + screen.y * record.camera.dir_dv);
+      normalize(pc.camera.dir_00 + screen.x * pc.camera.dir_du + screen.y * pc.camera.dir_dv);
   rayDesc.TMin = 0.0;
   rayDesc.TMax = 10000.0;
   RaytracingAccelerationStructure world = gprt::getAccelHandle(record.world);

--- a/samples/s04-computeAABBs/hostCode.cpp
+++ b/samples/s04-computeAABBs/hostCode.cpp
@@ -163,6 +163,10 @@ main(int ac, char **av) {
 
   LOG("launching ...");
 
+  // Structure of parameters that change each frame. We can edit these 
+  // without rebuilding the shader binding table.
+  PushConstants pc;
+
   bool firstFrame = true;
   double xpos = 0.f, ypos = 0.f;
   double lastxpos, lastypos;
@@ -203,27 +207,17 @@ main(int ac, char **av) {
       lookFrom = ((mul(rotationMatrixY, (position - pivot))) + pivot).xyz();
 
       // ----------- compute variable values  ------------------
-      float3 camera_pos = lookFrom;
-      float3 camera_d00 = normalize(lookAt - lookFrom);
+      pc.camera.pos = lookFrom;
+      pc.camera.dir_00 = normalize(lookAt - lookFrom);
       float aspect = float(fbSize.x) / float(fbSize.y);
-      float3 camera_ddu = cosFovy * aspect * normalize(cross(camera_d00, lookUp));
-      float3 camera_ddv = cosFovy * normalize(cross(camera_ddu, camera_d00));
-      camera_d00 -= 0.5f * camera_ddu;
-      camera_d00 -= 0.5f * camera_ddv;
-
-      // ----------- set variables  ----------------------------
-      RayGenData *raygenData = gprtRayGenGetParameters(rayGen);
-      raygenData->camera.pos = camera_pos;
-      raygenData->camera.dir_00 = camera_d00;
-      raygenData->camera.dir_du = camera_ddu;
-      raygenData->camera.dir_dv = camera_ddv;
-
-      // Use this to upload all set parameters to our ray tracing device
-      gprtBuildShaderBindingTable(context, GPRT_SBT_RAYGEN);
+      pc.camera.dir_du = cosFovy * aspect * normalize(cross(pc.camera.dir_00, lookUp));
+      pc.camera.dir_dv = cosFovy * normalize(cross(pc.camera.dir_du, pc.camera.dir_00));
+      pc.camera.dir_00 -= 0.5f * pc.camera.dir_du;
+      pc.camera.dir_00 -= 0.5f * pc.camera.dir_dv;
     }
 
     // Calls the GPU raygen kernel function
-    gprtRayGenLaunch2D(context, rayGen, fbSize.x, fbSize.y);
+    gprtRayGenLaunch2D(context, rayGen, fbSize.x, fbSize.y, pc);
 
     // If a window exists, presents the framebuffer here to that window
     gprtBufferPresent(context, frameBuffer);

--- a/samples/s04-computeAABBs/sharedCode.h
+++ b/samples/s04-computeAABBs/sharedCode.h
@@ -52,19 +52,21 @@ struct SphereGeomData {
 
 struct RayGenData {
   alignas(16) gprt::Buffer frameBuffer;
-
   alignas(16) gprt::Accel world;
-
-  struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
-  } camera;
 };
 
 /* variables for the miss program */
 struct MissProgData {
   alignas(16) float3 color0;
   alignas(16) float3 color1;
+};
+
+/* Constants that change each frame */
+struct PushConstants {
+  struct {
+    alignas(16) float3 pos;
+    alignas(16) float3 dir_00;
+    alignas(16) float3 dir_du;
+    alignas(16) float3 dir_dv;
+  } camera;
 };

--- a/samples/s05-computeVertex/hostCode.cpp
+++ b/samples/s05-computeVertex/hostCode.cpp
@@ -65,6 +65,11 @@ main(int ac, char **av) {
   GPRTContext context = gprtContextCreate(nullptr, 1);
   GPRTModule module = gprtModuleCreate(context, s05_deviceCode);
 
+  // Structure of parameters that change each frame. We can edit these 
+  // without rebuilding the shader binding table.
+  PushConstants pc;
+  pc.now = 0.f;
+
   // ##################################################################
   // set up all the GPU kernels we want to run
   // ##################################################################
@@ -113,21 +118,19 @@ main(int ac, char **av) {
   TrianglesGeomData *geomData = gprtGeomGetParameters(trianglesGeom);
   geomData->vertex = gprtBufferGetHandle(vertexBuffer);
   geomData->index = gprtBufferGetHandle(indexBuffer);
-  geomData->now = 0.f;
   geomData->gridSize = GRID_SIDE_LENGTH;
 
   // Parameters for our vertex program that'll animate our vertices
   TrianglesGeomData *vertexData = gprtComputeGetParameters(vertexProgram);
   vertexData->vertex = gprtBufferGetHandle(vertexBuffer);
   vertexData->index = gprtBufferGetHandle(indexBuffer);
-  vertexData->now = 0.f;
   vertexData->gridSize = GRID_SIDE_LENGTH;
 
   // Build the shader binding table to upload parameters to the device
   gprtBuildShaderBindingTable(context, GPRT_SBT_COMPUTE);
 
   // Now, compute triangles in parallel with a vertex compute shader
-  gprtComputeLaunch1D(context, vertexProgram, numTriangles);
+  gprtComputeLaunch1D(context, vertexProgram, numTriangles, pc);
 
   // Now that our vertex buffer and index buffer are filled, we can compute
   // our triangles acceleration structure.
@@ -207,29 +210,18 @@ main(int ac, char **av) {
       lookFrom = ((mul(rotationMatrixY, (position - pivot))) + pivot).xyz();
 
       // ----------- compute variable values  ------------------
-      float3 camera_pos = lookFrom;
-      float3 camera_d00 = normalize(lookAt - lookFrom);
+      pc.camera.pos = lookFrom;
+      pc.camera.dir_00 = normalize(lookAt - lookFrom);
       float aspect = float(fbSize.x) / float(fbSize.y);
-      float3 camera_ddu = cosFovy * aspect * normalize(cross(camera_d00, lookUp));
-      float3 camera_ddv = cosFovy * normalize(cross(camera_ddu, camera_d00));
-      camera_d00 -= 0.5f * camera_ddu;
-      camera_d00 -= 0.5f * camera_ddv;
-
-      // ----------- set variables  ----------------------------
-      RayGenData *raygenData = (RayGenData *) gprtRayGenGetParameters(rayGen);
-      raygenData->camera.pos = camera_pos;
-      raygenData->camera.dir_00 = camera_d00;
-      raygenData->camera.dir_du = camera_ddu;
-      raygenData->camera.dir_dv = camera_ddv;
-
-      // Use this to upload all set parameters to our ray tracing device
-      gprtBuildShaderBindingTable(context, GPRT_SBT_RAYGEN);
+      pc.camera.dir_du = cosFovy * aspect * normalize(cross(pc.camera.dir_00, lookUp));
+      pc.camera.dir_dv = cosFovy * normalize(cross(pc.camera.dir_du, pc.camera.dir_00));
+      pc.camera.dir_00 -= 0.5f * pc.camera.dir_du;
+      pc.camera.dir_00 -= 0.5f * pc.camera.dir_dv;
     }
 
     // update time to move primitives. then, rebuild accel.
-    vertexData->now = float(gprtGetTime(context));
-    gprtBuildShaderBindingTable(context, GPRT_SBT_COMPUTE);
-    gprtComputeLaunch1D(context, vertexProgram, numTriangles);
+    pc.now = float(gprtGetTime(context));
+    gprtComputeLaunch1D(context, vertexProgram, numTriangles, pc);
 
     // Now that the vertices have moved, we need to update our bottom level tree.
     // Note, updates should only be used when primitive counts are unchanged and 
@@ -241,7 +233,7 @@ main(int ac, char **av) {
     gprtAccelUpdate(context, world);
 
     // Calls the GPU raygen kernel function
-    gprtRayGenLaunch2D(context, rayGen, fbSize.x, fbSize.y);
+    gprtRayGenLaunch2D(context, rayGen, fbSize.x, fbSize.y, pc);
 
     // If a window exists, presents the framebuffer here to that window
     gprtBufferPresent(context, frameBuffer);

--- a/samples/s05-computeVertex/sharedCode.h
+++ b/samples/s05-computeVertex/sharedCode.h
@@ -27,27 +27,30 @@ struct TrianglesGeomData {
   alignas(16) gprt::Buffer index;
   /*! array/buffer of vertex positions */
   alignas(16) gprt::Buffer vertex;
-  /*! the current time */
-  alignas(4) float now;
   /*! the number of triangles along a row */
   alignas(4) unsigned int gridSize;
 };
 
 struct RayGenData {
   alignas(16) gprt::Buffer frameBuffer;
-
   alignas(16) gprt::Accel world;
-
-  struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
-  } camera;
 };
 
 /* variables for the miss program */
 struct MissProgData {
   alignas(16) float3 color0;
   alignas(16) float3 color1;
+};
+
+/* Constants that change each frame */
+struct PushConstants {
+  struct {
+    alignas(16) float3 pos;
+    alignas(16) float3 dir_00;
+    alignas(16) float3 dir_du;
+    alignas(16) float3 dir_dv;
+  } camera;
+
+  /*! the current time */
+  alignas(4) float now;
 };

--- a/samples/s06-computeTransform/deviceCode.hlsl
+++ b/samples/s06-computeTransform/deviceCode.hlsl
@@ -22,6 +22,8 @@
 
 #include "sharedCode.h"
 
+[[vk::push_constant]] PushConstants pc;
+
 GPRT_COMPUTE_PROGRAM(Transform, (TransformData, record), (1, 1, 1)) {
   int numTransforms = record.numTransforms;
   int length = sqrt(numTransforms);
@@ -32,8 +34,6 @@ GPRT_COMPUTE_PROGRAM(Transform, (TransformData, record), (1, 1, 1)) {
   float px = float(xid) / float(length);
   float py = float(yid) / float(length);
 
-  float now = record.now;
-
   float height = .1;
   float width = 4.0;
   float depth = 4.0;
@@ -41,7 +41,7 @@ GPRT_COMPUTE_PROGRAM(Transform, (TransformData, record), (1, 1, 1)) {
 
   float x = lerp(-1.f, 1.f, px);
   float y = lerp(-1.f, 1.f, py);
-  float z = sin(now + k * x) * cos(now + k * y);
+  float z = sin(pc.now + k * x) * cos(pc.now + k * y);
   float zoffset = x + y;
 
   float4 transforma = float4(0.04, 0.0, 0.0, x * width);
@@ -64,9 +64,9 @@ GPRT_RAYGEN_PROGRAM(RayGen, (RayGenData, record)) {
   uint2 fbSize = DispatchRaysDimensions().xy;
   float2 screen = (float2(pixelID) + float2(.5f, .5f)) / float2(fbSize);
   RayDesc rayDesc;
-  rayDesc.Origin = record.camera.pos;
+  rayDesc.Origin = pc.camera.pos;
   rayDesc.Direction =
-      normalize(record.camera.dir_00 + screen.x * record.camera.dir_du + screen.y * record.camera.dir_dv);
+      normalize(pc.camera.dir_00 + screen.x * pc.camera.dir_du + screen.y * pc.camera.dir_dv);
   rayDesc.TMin = 0.0;
   rayDesc.TMax = 10000.0;
   RaytracingAccelerationStructure world = gprt::getAccelHandle(record.world);

--- a/samples/s06-computeTransform/sharedCode.h
+++ b/samples/s06-computeTransform/sharedCode.h
@@ -27,8 +27,6 @@ struct TransformData {
   alignas(16) gprt::Buffer transforms;
   /*! the number of transforms stored in the buffer */
   alignas(4) int numTransforms;
-  /*! the current time */
-  alignas(4) float now;
 };
 
 struct TrianglesGeomData {
@@ -36,27 +34,30 @@ struct TrianglesGeomData {
   alignas(16) gprt::Buffer index;
   /*! array/buffer of vertex positions */
   alignas(16) gprt::Buffer vertex;
-  /*! the current time */
-  alignas(4) float now;
   /*! the number of triangles along a row */
   alignas(4) unsigned int gridSize;
 };
 
 struct RayGenData {
   alignas(16) gprt::Buffer frameBuffer;
-
   alignas(16) gprt::Accel world;
-
-  struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
-  } camera;
 };
 
 /* variables for the miss program */
 struct MissProgData {
   alignas(16) float3 color0;
   alignas(16) float3 color1;
+};
+
+/* Constants that change each frame */
+struct PushConstants {
+  struct {
+    alignas(16) float3 pos;
+    alignas(16) float3 dir_00;
+    alignas(16) float3 dir_du;
+    alignas(16) float3 dir_dv;
+  } camera;
+
+  /*! the current time */
+  alignas(4) float now;
 };

--- a/samples/s07-multipleGeometry/deviceCode.hlsl
+++ b/samples/s07-multipleGeometry/deviceCode.hlsl
@@ -22,6 +22,8 @@
 
 #include "sharedCode.h"
 
+[[vk::push_constant]] PushConstants pc;
+
 struct [raypayload] Payload {
   float3 color : read(caller) : write(closesthit, miss);
 };
@@ -34,9 +36,9 @@ GPRT_RAYGEN_PROGRAM(raygen, (RayGenData, record)) {
 
   // Generate ray
   RayDesc rayDesc;
-  rayDesc.Origin = record.camera.pos;
+  rayDesc.Origin = pc.camera.pos;
   rayDesc.Direction =
-      normalize(record.camera.dir_00 + screen.x * record.camera.dir_du + screen.y * record.camera.dir_dv);
+      normalize(pc.camera.dir_00 + screen.x * pc.camera.dir_du + screen.y * pc.camera.dir_dv);
   rayDesc.TMin = 0.0;
   rayDesc.TMax = 1e20f;
 

--- a/samples/s07-multipleGeometry/hostCode.cpp
+++ b/samples/s07-multipleGeometry/hostCode.cpp
@@ -177,6 +177,10 @@ main(int ac, char **av) {
 
   LOG("launching ...");
 
+  // Structure of parameters that change each frame. We can edit these 
+  // without rebuilding the shader binding table.
+  PushConstants pc;
+
   bool firstFrame = true;
   double xpos = 0.f, ypos = 0.f;
   double lastxpos, lastypos;
@@ -217,26 +221,17 @@ main(int ac, char **av) {
       lookFrom = ((mul(rotationMatrixY, (position - pivot))) + pivot).xyz();
 
       // ----------- compute variable values  ------------------
-      float3 camera_pos = lookFrom;
-      float3 camera_d00 = normalize(lookAt - lookFrom);
+      pc.camera.pos = lookFrom;
+      pc.camera.dir_00 = normalize(lookAt - lookFrom);
       float aspect = float(fbSize.x) / float(fbSize.y);
-      float3 camera_ddu = cosFovy * aspect * normalize(cross(camera_d00, lookUp));
-      float3 camera_ddv = cosFovy * normalize(cross(camera_ddu, camera_d00));
-      camera_d00 -= 0.5f * camera_ddu;
-      camera_d00 -= 0.5f * camera_ddv;
-
-      // ----------- set variables  ----------------------------
-      RayGenData *raygenData = gprtRayGenGetParameters(rayGen);
-      raygenData->camera.pos = camera_pos;
-      raygenData->camera.dir_00 = camera_d00;
-      raygenData->camera.dir_du = camera_ddu;
-      raygenData->camera.dir_dv = camera_ddv;
-
-      gprtBuildShaderBindingTable(context, GPRT_SBT_RAYGEN);
+      pc.camera.dir_du = cosFovy * aspect * normalize(cross(pc.camera.dir_00, lookUp));
+      pc.camera.dir_dv = cosFovy * normalize(cross(pc.camera.dir_du, pc.camera.dir_00));
+      pc.camera.dir_00 -= 0.5f * pc.camera.dir_du;
+      pc.camera.dir_00 -= 0.5f * pc.camera.dir_dv;
     }
 
     // Calls the GPU raygen kernel function
-    gprtRayGenLaunch2D(context, rayGen, fbSize.x, fbSize.y);
+    gprtRayGenLaunch2D(context, rayGen, fbSize.x, fbSize.y, pc);
 
     // If a window exists, presents the framebuffer here to that window
     gprtBufferPresent(context, frameBuffer);

--- a/samples/s07-multipleGeometry/sharedCode.h
+++ b/samples/s07-multipleGeometry/sharedCode.h
@@ -36,19 +36,21 @@ struct TrianglesGeomData {
 
 struct RayGenData {
   alignas(16) gprt::Buffer frameBuffer;
-
   alignas(16) gprt::Accel world;
-
-  struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
-  } camera;
 };
 
 /* variables for the miss program */
 struct MissProgData {
   alignas(16) float3 color0;
   alignas(16) float3 color1;
+};
+
+/* Constants that change each frame */
+struct PushConstants {
+  struct {
+    alignas(16) float3 pos;
+    alignas(16) float3 dir_00;
+    alignas(16) float3 dir_du;
+    alignas(16) float3 dir_dv;
+  } camera;
 };

--- a/samples/s08-singleTexture/sharedCode.h
+++ b/samples/s08-singleTexture/sharedCode.h
@@ -28,8 +28,6 @@ struct TransformData {
   /*! array/buffer of instance transforms */
   alignas(16) gprt::Buffer transforms;
   alignas(4) int numTransforms;
-  /*! the current time */
-  alignas(4) float now;
 };
 
 /* variables for the triangle mesh geometry */
@@ -44,16 +42,22 @@ struct TrianglesGeomData {
   alignas(16) gprt::Texture texture;
   /*! an array of texture samplers to use */
   alignas(16) gprt::Sampler samplers[12];
-  /*! the current time */
-  alignas(8) float now;
 };
 
 struct RayGenData {
   alignas(16) gprt::Accel world;
   alignas(16) gprt::Buffer framebuffer;
-
   alignas(8) int2 fbSize;
+};
 
+/* variables for the miss program */
+struct MissProgData {
+  alignas(16) float3 color0;
+  alignas(16) float3 color1;
+};
+
+/* Constants that change each frame */
+struct PushConstants {
   struct {
     alignas(16) float3 pos;
     alignas(16) float3 dir_00;
@@ -61,10 +65,7 @@ struct RayGenData {
     alignas(16) float3 dir_dv;
     alignas(4) float fovy;
   } camera;
-};
 
-/* variables for the miss program */
-struct MissProgData {
-  alignas(16) float3 color0;
-  alignas(16) float3 color1;
+  /*! the current time */
+  alignas(8) float now;
 };

--- a/samples/s09-visibilityMasks/deviceCode.hlsl
+++ b/samples/s09-visibilityMasks/deviceCode.hlsl
@@ -22,6 +22,8 @@
 
 #include "sharedCode.h"
 
+[[vk::push_constant]] PushConstants pc;
+
 struct [raypayload] Payload {
   float4 color  : read(caller) : write(closesthit, miss);
   float3 normal : read(caller) : write(closesthit, miss);
@@ -43,9 +45,9 @@ GPRT_RAYGEN_PROGRAM(simpleRayGen, (RayGenData, record)) {
   float2 screen = (float2(pixelID) + float2(.5f, .5f)) / float2(fbSize);
 
   RayDesc rayDesc;
-  rayDesc.Origin = record.camera.pos;
+  rayDesc.Origin = pc.camera.pos;
   rayDesc.Direction =
-      normalize(record.camera.dir_00 + screen.x * record.camera.dir_du + screen.y * record.camera.dir_dv);
+      normalize(pc.camera.dir_00 + screen.x * pc.camera.dir_du + screen.y * pc.camera.dir_dv);
   rayDesc.TMin = 0.001;
   rayDesc.TMax = 10000.0;
   RaytracingAccelerationStructure world = gprt::getAccelHandle(record.world);
@@ -99,7 +101,7 @@ GPRT_RAYGEN_PROGRAM(simpleRayGen, (RayGenData, record)) {
 
     // note, adding a normal offset to avoid self-intersections
     rayDesc.Origin = hitPos + .001f * normal;
-    rayDesc.Direction = normalize(record.lightPos);
+    rayDesc.Direction = normalize(pc.lightPos);
 
     // Trace our primary visibility ray
     TraceRay(world,                   // the tree
@@ -117,7 +119,7 @@ GPRT_RAYGEN_PROGRAM(simpleRayGen, (RayGenData, record)) {
 
     // We hit the light
     if (payload.hitT == -1.f) {
-      litColor += color * max(dot(normal, rayDesc.Direction), 0.0f) * (1.f - ambient) * record.lightColor;
+      litColor += color * max(dot(normal, rayDesc.Direction), 0.0f) * (1.f - ambient) * pc.lightColor;
     }
 
     shadedColor = over(transparentColor, float4(litColor, 1.f));

--- a/samples/s09-visibilityMasks/sharedCode.h
+++ b/samples/s09-visibilityMasks/sharedCode.h
@@ -33,9 +33,17 @@ struct TrianglesGeomData {
 
 struct RayGenData {
   alignas(16) gprt::Buffer frameBuffer;
-
   alignas(16) gprt::Accel world;
+};
 
+/* variables for the miss program */
+struct MissProgData {
+  alignas(16) float3 color0;
+  alignas(16) float3 color1;
+};
+
+/* Constants that change each frame */
+struct PushConstants {
   struct {
     alignas(16) float3 pos;
     alignas(16) float3 dir_00;
@@ -45,10 +53,4 @@ struct RayGenData {
 
   alignas(16) float3 lightColor;
   alignas(16) float3 lightPos;
-};
-
-/* variables for the miss program */
-struct MissProgData {
-  alignas(16) float3 color0;
-  alignas(16) float3 color1;
 };

--- a/samples/s10-rasterization/deviceCode.hlsl
+++ b/samples/s10-rasterization/deviceCode.hlsl
@@ -1,5 +1,7 @@
 #include "sharedCode.h"
 
+[[vk::push_constant]] PushConstants pc;
+
 GPRT_VERTEX_PROGRAM(backgroundVertex, (BackgroundData, record)) {
   uint32_t vertexID = VertexIndex();
   float3 position = gprt::load<float3>(record.vertex, vertexID);
@@ -15,8 +17,8 @@ GPRT_PIXEL_PROGRAM(backgroundPixel, (BackgroundData, record)) {
 
 GPRT_VERTEX_PROGRAM(simpleVertex, (TrianglesGeomData, record)) {
   uint32_t vertexID = VertexIndex();
-  float4x4 view = record.view;
-  float4x4 proj = record.proj;
+  float4x4 view = pc.view;
+  float4x4 proj = pc.proj;
   float4 position = float4(gprt::load<float3>(record.vertex, vertexID), 1.f);
   position = mul(view, position);
   position = mul(proj, position);

--- a/samples/s10-rasterization/sharedCode.h
+++ b/samples/s10-rasterization/sharedCode.h
@@ -28,9 +28,6 @@ struct TrianglesGeomData {
   alignas(16) gprt::Buffer index;    // int3*
   alignas(16) gprt::Buffer vertex;   // float3*
   alignas(16) gprt::Buffer color;    // float3*
-
-  alignas(16) float4x4 view;
-  alignas(16) float4x4 proj;
 };
 
 /* variables for the geometry representing the background */
@@ -39,4 +36,10 @@ struct BackgroundData {
   alignas(16) gprt::Buffer vertex;   // float3*
   alignas(16) float3 color0;
   alignas(16) float3 color1;
+};
+
+/* Constants that change each frame */
+struct PushConstants {
+  alignas(16) float4x4 view;
+  alignas(16) float4x4 proj;
 };

--- a/samples/s11-imgui/deviceCode.hlsl
+++ b/samples/s11-imgui/deviceCode.hlsl
@@ -1,5 +1,7 @@
 #include "sharedCode.h"
 
+[[vk::push_constant]] PushConstants pc;
+
 GPRT_VERTEX_PROGRAM(backgroundVertex, (BackgroundData, record)) {
   uint32_t vertexID = VertexIndex();
   float3 position = gprt::load<float3>(record.vertex, vertexID);
@@ -28,8 +30,8 @@ GPRT_PIXEL_PROGRAM(GUIPixel, (GUIData, record)) {
 
 GPRT_VERTEX_PROGRAM(simpleVertex, (TrianglesGeomData, record)) {
   uint32_t vertexID = VertexIndex();
-  float4x4 view = record.view;
-  float4x4 proj = record.proj;
+  float4x4 view = pc.view;
+  float4x4 proj = pc.proj;
   float4 position = float4(gprt::load<float3>(record.vertex, vertexID), 1.f);
   position = mul(view, position);
   position = mul(proj, position);

--- a/samples/s11-imgui/hostCode.cpp
+++ b/samples/s11-imgui/hostCode.cpp
@@ -191,6 +191,8 @@ main(int ac, char **av) {
 
   LOG("launching ...");
 
+  PushConstants pc;
+
   bool firstFrame = true;
   double xpos = 0.f, ypos = 0.f;
   double lastxpos, lastypos;
@@ -234,13 +236,8 @@ main(int ac, char **av) {
       lookFrom = ((mul(rotationMatrixY, (position - pivot))) + pivot).xyz();
 
       float aspect = float(fbSize.x) / float(fbSize.y);
-      float4x4 lookAtMatrix = lookat_matrix(position.xyz(), pivot.xyz(), lookUp);
-      float4x4 perspectiveMatrix = perspective_matrix(cosFovy, aspect, 0.1f, 1000.f);
-
-      tridata->view = lookAtMatrix;
-      tridata->proj = perspectiveMatrix;
-
-      gprtBuildShaderBindingTable(context, GPRT_SBT_RASTER);
+      pc.view = lookat_matrix(position.xyz(), pivot.xyz(), lookUp);
+      pc.proj = perspective_matrix(cosFovy, aspect, 0.1f, 1000.f);
     }
 
     // Draw our background and triangle
@@ -248,11 +245,11 @@ main(int ac, char **av) {
     gprtTextureClear(colorAttachment);
 
     std::vector<GPRTGeomOf<BackgroundData>> drawList1 = {bgGeom};
-    gprtGeomTypeRasterize(context, backdropGeomType, drawList1.size(), drawList1.data());
+    gprtGeomTypeRasterize(context, backdropGeomType, drawList1.size(), drawList1.data(), 0, nullptr, pc);
     gprtTextureClear(depthAttachment);
 
     std::vector<GPRTGeomOf<TrianglesGeomData>> drawList2 = {trianglesGeom};
-    gprtGeomTypeRasterize(context, trianglesGeomType, drawList2.size(), drawList2.data());
+    gprtGeomTypeRasterize(context, trianglesGeomType, drawList2.size(), drawList2.data(), 0, nullptr, pc);
     gprtTextureClear(depthAttachment);
 
     // Set our ImGui state
@@ -268,7 +265,7 @@ main(int ac, char **av) {
 
     // Finally, composite the gui onto the screen.
     std::vector<GPRTGeomOf<GUIData>> drawList3 = {guiGeom};
-    gprtGeomTypeRasterize(context, guiGeomType, drawList3.size(), drawList3.data());
+    gprtGeomTypeRasterize(context, guiGeomType, drawList3.size(), drawList3.data(), 0, nullptr, pc);
 
     // If a window exists, presents the framebuffer here to that window
     gprtTexturePresent(context, colorAttachment);

--- a/samples/s11-imgui/sharedCode.h
+++ b/samples/s11-imgui/sharedCode.h
@@ -28,9 +28,6 @@ struct TrianglesGeomData {
   alignas(16) gprt::Buffer index;    // int3*
   alignas(16) gprt::Buffer vertex;   // float3*
   alignas(16) gprt::Buffer color;    // float3*
-
-  alignas(16) float4x4 view;
-  alignas(16) float4x4 proj;
 };
 
 /* variables for the geometry representing the background */
@@ -47,4 +44,10 @@ struct GUIData {
   alignas(16) gprt::Buffer vertex;   // float3*
   alignas(16) gprt::Texture texture;
   alignas(8) float2 resolution;
+};
+
+/* Constants that change each frame */
+struct PushConstants {
+  alignas(16) float4x4 view;
+  alignas(16) float4x4 proj;
 };

--- a/samples/s12-swBVH/sharedCode.h
+++ b/samples/s12-swBVH/sharedCode.h
@@ -27,9 +27,17 @@
 struct RayGenData {
   alignas(16) gprt::Buffer frameBuffer;
   alignas(16) gprt::Buffer accumBuffer;
-
   LBVHData lbvh;
+};
 
+/* variables for the miss program */
+struct MissProgData {
+  alignas(16) float3 color0;
+  alignas(16) float3 color1;
+};
+
+/* Constants that change each frame */
+struct PushConstants {
   alignas(4) float iTime;
   alignas(4) int iFrame;
   alignas(4) float cuttingPlane;
@@ -40,10 +48,4 @@ struct RayGenData {
     alignas(16) float3 dir_du;
     alignas(16) float3 dir_dv;
   } camera;
-};
-
-/* variables for the miss program */
-struct MissProgData {
-  alignas(16) float3 color0;
-  alignas(16) float3 color1;
 };


### PR DESCRIPTION
This PR introduces a change to the GPRT API to allow users to upload a small set of push constants when launching raygen, compute, and raster programs.

Push constants are a Vulkan mechanism that allows users to parameterize their shaders without using buffers, or making changes to the shader binding table. 

The compromise is that push constant structures are very small---128 bytes or less---but these can still be very useful for small, regular changes like camera manipulation, frame IDs, buffer selection for compute shaders, etc. 