### PR TITLE
Migrate to scalar struct alignment rules

### DIFF
--- a/gprt/cmake/embed_devicecode.cmake
+++ b/gprt/cmake/embed_devicecode.cmake
@@ -84,6 +84,9 @@ function(embed_devicecode)
       -fspv-extension=SPV_KHR_physical_storage_buffer
       -fspv-extension=SPV_KHR_vulkan_memory_model
       -fspv-extension=SPV_EXT_descriptor_indexing
+      # Below scalar layout flag makes structures in HLSL match C/C++ struct alignment. 
+      # For example, float3's with size 12 align to a 12 byte boundary rather than 16. 
+      -fvk-use-scalar-layout
       -fcgl
       ${EMBED_DEVICECODE_SOURCES}
       -Fo ${CMAKE_CURRENT_BINARY_DIR}/${EMBED_DEVICECODE_OUTPUT_TARGET}_${ENTRY_POINT_TYPE}.spv

--- a/gprt/gprt.cpp
+++ b/gprt/gprt.cpp
@@ -5301,6 +5301,11 @@ struct Context {
       return requiredExtensions.empty();
     };
 
+    // This makes structs follow a C-like structure. Modifies alignment rules for uniform buffers,
+    // sortage buffers and push constants, allowing non-scalar types to be aligned solely based on the size of their
+    // components, without additional requirements.
+    enabledDeviceExtensions.push_back(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME);
+
     // Ray tracing related extensions required
 
     enabledDeviceExtensions.push_back(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
@@ -5537,6 +5542,10 @@ struct Context {
     // }
 
     /// 3. Create the logical device representation
+    VkPhysicalDeviceScalarBlockLayoutFeatures physicalDeviceScalarBlocklayoutFeatures = {};
+    physicalDeviceScalarBlocklayoutFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES;
+    physicalDeviceScalarBlocklayoutFeatures.scalarBlockLayout = true;
+
     VkPhysicalDeviceVulkanMemoryModelFeatures memoryModelFeatures = {};
     memoryModelFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES;
 

--- a/gprt/gprt_device.h
+++ b/gprt/gprt_device.h
@@ -29,8 +29,6 @@
  */
 #pragma once 
 
-#define alignas(alignment)
-
 // struct PushConstants {
 //   uint64_t r[16];
 // };

--- a/gprt/gprt_host.h
+++ b/gprt/gprt_host.h
@@ -28,7 +28,6 @@
  * SOFTWARE.
  */
 
-#include <cstdalign>
 #include <vulkan/vulkan.h>
 
 #include "linalg.h"

--- a/gprt/gprt_lbvh.h
+++ b/gprt/gprt_lbvh.h
@@ -25,31 +25,31 @@
 
 struct LBVHData {
   // input
-  alignas(4) uint32_t numPrims;
-  alignas(4) uint32_t numNodes;
-  alignas(4) uint32_t numInner;
-  alignas(4) uint32_t tmp;
-  alignas(16) gprt::Buffer positions;
-  alignas(16) gprt::Buffer edges;
-  alignas(16) gprt::Buffer triangles;
+  uint32_t numPrims;
+  uint32_t numNodes;
+  uint32_t numInner;
+  uint32_t tmp;
+  gprt::Buffer positions;
+  gprt::Buffer edges;
+  gprt::Buffer triangles;
 
   // Morton codes of quantized primitive centroids
   // One uint32_t per primitive
-  alignas(16) gprt::Buffer mortonCodes;
+  gprt::Buffer mortonCodes;
 
   // Primitive IDs that correspond to sorted morton codes. 
   // One uint32_t per primitive
-  alignas(16) gprt::Buffer ids;
+  gprt::Buffer ids;
   
   // numPrims-1 + numPrims long. 
   // The "numPrims-1" section contains inner nodes
   // The "numPrims" section contains leaves
   // Each node is an int4. 
   // "X" is left, "Y" is right, "Z" is parent, and "W" is leaf or -1 if internal node.
-  alignas(16) gprt::Buffer nodes;
+  gprt::Buffer nodes;
 
   // numPrims-1 + numPrims long. Each aabb is a pair of float3.
-  alignas(16) gprt::Buffer aabbs;
+  gprt::Buffer aabbs;
 };
 
 #ifndef GPRT_DEVICE

--- a/samples/s00-rayGenOnly/sharedCode.h
+++ b/samples/s00-rayGenOnly/sharedCode.h
@@ -22,10 +22,8 @@
 
 #include "gprt.h"
 
-// note! HLSL aligns to 16-byte boundaries!
 struct RayGenData {
-  // pointers are represented using uint64_t
-  alignas(16) float3 color0;   // note the 16 byte alignment (not 12 byte) here
-  alignas(16) float3 color1;   // note the 16 byte alignment (not 12 byte) here
-  alignas(16) gprt::Buffer frameBuffer;
+  float3 color0;
+  float3 color1;
+  gprt::Buffer frameBuffer;
 };

--- a/samples/s01-singleTriangle/sharedCode.h
+++ b/samples/s01-singleTriangle/sharedCode.h
@@ -26,27 +26,27 @@
 
 /* variables for the triangle mesh geometry */
 struct TrianglesGeomData {
-  alignas(8) int tmp;   // unused for now
+  int tmp;   // unused for now
 };
 
 struct RayGenData {
-  alignas(16) gprt::Buffer frameBuffer;
-  alignas(16) gprt::Accel world;
+  gprt::Buffer frameBuffer;
+  gprt::Accel world;
 };
 
 /* variables for the miss program */
 struct MissProgData {
-  alignas(16) float3 color0;
-  alignas(16) float3 color1;
+  float3 color0;
+  float3 color1;
 };
 
 /* A small structure of constants that can change every frame without rebuilding the 
   shader binding table. (must be 128 bytes or less) */
 struct PushConstants {
   struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
+    float3 pos;
+    float3 dir_00;
+    float3 dir_du;
+    float3 dir_dv;
   } camera;
 };

--- a/samples/s02-instances/sharedCode.h
+++ b/samples/s02-instances/sharedCode.h
@@ -27,28 +27,28 @@
 /* variables for the triangle mesh geometry */
 struct TrianglesGeomData {
   /*! array/buffer of vertex indices */
-  alignas(16) gprt::Buffer index;   // vec3i*
+  gprt::Buffer index;   // vec3i*
   /*! array/buffer of vertex positions */
-  alignas(16) gprt::Buffer vertex;   // vec3f *
+  gprt::Buffer vertex;   // vec3f *
 };
 
 struct RayGenData {
-  alignas(16) gprt::Buffer frameBuffer;
-  alignas(16) gprt::Accel world;
+  gprt::Buffer frameBuffer;
+  gprt::Accel world;
 };
 
 /* variables for the miss program */
 struct MissProgData {
-  alignas(16) float3 color0;
-  alignas(16) float3 color1;
+  float3 color0;
+  float3 color1;
 };
 
 /* Constants that change each frame */
 struct PushConstants {
   struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
+    float3 pos;
+    float3 dir_00;
+    float3 dir_du;
+    float3 dir_dv;
   } camera;
 };

--- a/samples/s03-singleAABB/sharedCode.h
+++ b/samples/s03-singleAABB/sharedCode.h
@@ -26,26 +26,26 @@
 
 /* variables for the triangle mesh geometry */
 struct AABBGeomData {
-  alignas(8) int tmp;   // unused for now
+  int tmp;   // unused for now
 };
 
 struct RayGenData {
-  alignas(16) gprt::Buffer frameBuffer;
-  alignas(16) gprt::Accel world;
+  gprt::Buffer frameBuffer;
+  gprt::Accel world;
 };
 
 /* variables for the miss program */
 struct MissProgData {
-  alignas(16) float3 color0;
-  alignas(16) float3 color1;
+  float3 color0;
+  float3 color1;
 };
 
 /* Constants that change each frame */
 struct PushConstants {
   struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
+    float3 pos;
+    float3 dir_00;
+    float3 dir_du;
+    float3 dir_dv;
   } camera;
 };

--- a/samples/s04-computeAABBs/sharedCode.h
+++ b/samples/s04-computeAABBs/sharedCode.h
@@ -26,47 +26,47 @@
 
 struct SphereBoundsData {
   /*! array/buffer of vertex indices */
-  alignas(16) gprt::Buffer vertex;   // vec3f*
+  gprt::Buffer vertex;   // vec3f*
   /*! array/buffer of vertex positions */
-  alignas(16) gprt::Buffer radius;   // float *
+  gprt::Buffer radius;   // float *
   /*! array/buffer of AABBs */
-  alignas(16) gprt::Buffer aabbs;
+  gprt::Buffer aabbs;
 };
 
 struct SphereBoundsData2 {
   /*! array/buffer of vertex indices */
-  alignas(16) gprt::Buffer vertex;   // vec3f*
+  gprt::Buffer vertex;   // vec3f*
   /*! array/buffer of vertex positions */
-  alignas(16) gprt::Buffer radius;   // float *
+  gprt::Buffer radius;   // float *
   /*! array/buffer of AABBs */
-  alignas(16) gprt::Buffer aabbs;
+  gprt::Buffer aabbs;
 };
 
 /* variables for the triangle mesh geometry */
 struct SphereGeomData {
   /*! array/buffer of vertex indices */
-  alignas(16) gprt::Buffer vertex;   // vec3f*
+  gprt::Buffer vertex;   // vec3f*
   /*! array/buffer of vertex positions */
-  alignas(16) gprt::Buffer radius;   // float *
+  gprt::Buffer radius;   // float *
 };
 
 struct RayGenData {
-  alignas(16) gprt::Buffer frameBuffer;
-  alignas(16) gprt::Accel world;
+  gprt::Buffer frameBuffer;
+  gprt::Accel world;
 };
 
 /* variables for the miss program */
 struct MissProgData {
-  alignas(16) float3 color0;
-  alignas(16) float3 color1;
+  float3 color0;
+  float3 color1;
 };
 
 /* Constants that change each frame */
 struct PushConstants {
   struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
+    float3 pos;
+    float3 dir_00;
+    float3 dir_du;
+    float3 dir_dv;
   } camera;
 };

--- a/samples/s05-computeVertex/sharedCode.h
+++ b/samples/s05-computeVertex/sharedCode.h
@@ -24,33 +24,33 @@
 
 struct TrianglesGeomData {
   /*! array/buffer of vertex indices */
-  alignas(16) gprt::Buffer index;
+  gprt::Buffer index;
   /*! array/buffer of vertex positions */
-  alignas(16) gprt::Buffer vertex;
+  gprt::Buffer vertex;
   /*! the number of triangles along a row */
-  alignas(4) unsigned int gridSize;
+  unsigned int gridSize;
 };
 
 struct RayGenData {
-  alignas(16) gprt::Buffer frameBuffer;
-  alignas(16) gprt::Accel world;
+  gprt::Buffer frameBuffer;
+  gprt::Accel world;
 };
 
 /* variables for the miss program */
 struct MissProgData {
-  alignas(16) float3 color0;
-  alignas(16) float3 color1;
+  float3 color0;
+  float3 color1;
 };
 
 /* Constants that change each frame */
 struct PushConstants {
   struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
+    float3 pos;
+    float3 dir_00;
+    float3 dir_du;
+    float3 dir_dv;
   } camera;
 
   /*! the current time */
-  alignas(4) float now;
+  float now;
 };

--- a/samples/s06-computeTransform/sharedCode.h
+++ b/samples/s06-computeTransform/sharedCode.h
@@ -24,40 +24,40 @@
 
 struct TransformData {
   /*! array/buffer of instance transforms */
-  alignas(16) gprt::Buffer transforms;
+  gprt::Buffer transforms;
   /*! the number of transforms stored in the buffer */
-  alignas(4) int numTransforms;
+  int numTransforms;
 };
 
 struct TrianglesGeomData {
   /*! array/buffer of vertex indices */
-  alignas(16) gprt::Buffer index;
+  gprt::Buffer index;
   /*! array/buffer of vertex positions */
-  alignas(16) gprt::Buffer vertex;
+  gprt::Buffer vertex;
   /*! the number of triangles along a row */
-  alignas(4) unsigned int gridSize;
+  unsigned int gridSize;
 };
 
 struct RayGenData {
-  alignas(16) gprt::Buffer frameBuffer;
-  alignas(16) gprt::Accel world;
+  gprt::Buffer frameBuffer;
+  gprt::Accel world;
 };
 
 /* variables for the miss program */
 struct MissProgData {
-  alignas(16) float3 color0;
-  alignas(16) float3 color1;
+  float3 color0;
+  float3 color1;
 };
 
 /* Constants that change each frame */
 struct PushConstants {
   struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
+    float3 pos;
+    float3 dir_00;
+    float3 dir_du;
+    float3 dir_dv;
   } camera;
 
   /*! the current time */
-  alignas(4) float now;
+  float now;
 };

--- a/samples/s07-multipleGeometry/sharedCode.h
+++ b/samples/s07-multipleGeometry/sharedCode.h
@@ -27,30 +27,30 @@
 /* variables for the triangle mesh geometry */
 struct TrianglesGeomData {
   /*! array/buffer of vertex indices */
-  alignas(16) gprt::Buffer index;   // vec3i*
+  gprt::Buffer index;   // vec3i*
   /*! array/buffer of vertex positions */
-  alignas(16) gprt::Buffer vertex;   // vec3f *
+  gprt::Buffer vertex;   // vec3f *
   /*! base color we use for the entire mesh */
-  alignas(16) float3 color;
+  float3 color;
 };
 
 struct RayGenData {
-  alignas(16) gprt::Buffer frameBuffer;
-  alignas(16) gprt::Accel world;
+  gprt::Buffer frameBuffer;
+  gprt::Accel world;
 };
 
 /* variables for the miss program */
 struct MissProgData {
-  alignas(16) float3 color0;
-  alignas(16) float3 color1;
+  float3 color0;
+  float3 color1;
 };
 
 /* Constants that change each frame */
 struct PushConstants {
   struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
+    float3 pos;
+    float3 dir_00;
+    float3 dir_du;
+    float3 dir_dv;
   } camera;
 };

--- a/samples/s08-singleTexture/sharedCode.h
+++ b/samples/s08-singleTexture/sharedCode.h
@@ -26,46 +26,46 @@
 
 struct TransformData {
   /*! array/buffer of instance transforms */
-  alignas(16) gprt::Buffer transforms;
-  alignas(4) int numTransforms;
+  gprt::Buffer transforms;
+  int numTransforms;
 };
 
 /* variables for the triangle mesh geometry */
 struct TrianglesGeomData {
   /*! array/buffer of vertex indices */
-  alignas(16) gprt::Buffer index;   // vec3i*
+  gprt::Buffer index;   // vec3i*
   /*! array/buffer of vertex positions */
-  alignas(16) gprt::Buffer vertex;   // vec3f *
+  gprt::Buffer vertex;   // vec3f *
   /*! array/buffer of vertex positions */
-  alignas(16) gprt::Buffer texcoord;   // vec2f *
+  gprt::Buffer texcoord;   // vec2f *
   /*! base color texture we use for the entire mesh */
-  alignas(16) gprt::Texture texture;
+  gprt::Texture texture;
   /*! an array of texture samplers to use */
-  alignas(16) gprt::Sampler samplers[12];
+  gprt::Sampler samplers[12];
 };
 
 struct RayGenData {
-  alignas(16) gprt::Accel world;
-  alignas(16) gprt::Buffer framebuffer;
-  alignas(8) int2 fbSize;
+  gprt::Accel world;
+  gprt::Buffer framebuffer;
+  int2 fbSize;
 };
 
 /* variables for the miss program */
 struct MissProgData {
-  alignas(16) float3 color0;
-  alignas(16) float3 color1;
+  float3 color0;
+  float3 color1;
 };
 
 /* Constants that change each frame */
 struct PushConstants {
   struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
-    alignas(4) float fovy;
+    float3 pos;
+    float3 dir_00;
+    float3 dir_du;
+    float3 dir_dv;
+    float fovy;
   } camera;
 
   /*! the current time */
-  alignas(8) float now;
+  float now;
 };

--- a/samples/s09-visibilityMasks/sharedCode.h
+++ b/samples/s09-visibilityMasks/sharedCode.h
@@ -26,31 +26,31 @@
 
 /* variables for the triangle mesh geometry */
 struct TrianglesGeomData {
-  alignas(16) gprt::Buffer indices;
-  alignas(16) gprt::Buffer vertices;
-  alignas(16) float4 color;
+  gprt::Buffer indices;
+  gprt::Buffer vertices;
+  float4 color;
 };
 
 struct RayGenData {
-  alignas(16) gprt::Buffer frameBuffer;
-  alignas(16) gprt::Accel world;
+  gprt::Buffer frameBuffer;
+  gprt::Accel world;
 };
 
 /* variables for the miss program */
 struct MissProgData {
-  alignas(16) float3 color0;
-  alignas(16) float3 color1;
+  float3 color0;
+  float3 color1;
 };
 
 /* Constants that change each frame */
 struct PushConstants {
   struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
+    float3 pos;
+    float3 dir_00;
+    float3 dir_du;
+    float3 dir_dv;
   } camera;
 
-  alignas(16) float3 lightColor;
-  alignas(16) float3 lightPos;
+  float3 lightColor;
+  float3 lightPos;
 };

--- a/samples/s10-rasterization/sharedCode.h
+++ b/samples/s10-rasterization/sharedCode.h
@@ -25,21 +25,21 @@
 // note! HLSL aligns to float4 boundaries!
 struct TrianglesGeomData {
   /*! array/buffer of vertex indices */
-  alignas(16) gprt::Buffer index;    // int3*
-  alignas(16) gprt::Buffer vertex;   // float3*
-  alignas(16) gprt::Buffer color;    // float3*
+  gprt::Buffer index;    // int3*
+  gprt::Buffer vertex;   // float3*
+  gprt::Buffer color;    // float3*
 };
 
 /* variables for the geometry representing the background */
 struct BackgroundData {
-  alignas(16) gprt::Buffer index;    // int3*
-  alignas(16) gprt::Buffer vertex;   // float3*
-  alignas(16) float3 color0;
-  alignas(16) float3 color1;
+  gprt::Buffer index;    // int3*
+  gprt::Buffer vertex;   // float3*
+  float3 color0;
+  float3 color1;
 };
 
 /* Constants that change each frame */
 struct PushConstants {
-  alignas(16) float4x4 view;
-  alignas(16) float4x4 proj;
+  float4x4 view;
+  float4x4 proj;
 };

--- a/samples/s11-imgui/sharedCode.h
+++ b/samples/s11-imgui/sharedCode.h
@@ -25,29 +25,29 @@
 // note! HLSL aligns to float4 boundaries!
 struct TrianglesGeomData {
   /*! array/buffer of vertex indices */
-  alignas(16) gprt::Buffer index;    // int3*
-  alignas(16) gprt::Buffer vertex;   // float3*
-  alignas(16) gprt::Buffer color;    // float3*
+  gprt::Buffer index;    // int3*
+  gprt::Buffer vertex;   // float3*
+  gprt::Buffer color;    // float3*
 };
 
 /* variables for the geometry representing the background */
 struct BackgroundData {
-  alignas(16) gprt::Buffer index;    // int3*
-  alignas(16) gprt::Buffer vertex;   // float3*
-  alignas(16) float3 color0;
-  alignas(16) float3 color1;
+  gprt::Buffer index;    // int3*
+  gprt::Buffer vertex;   // float3*
+  float3 color0;
+  float3 color1;
 };
 
 /* variables for the geometry representing the background */
 struct GUIData {
-  alignas(16) gprt::Buffer index;    // int3*
-  alignas(16) gprt::Buffer vertex;   // float3*
-  alignas(16) gprt::Texture texture;
-  alignas(8) float2 resolution;
+  gprt::Buffer index;    // int3*
+  gprt::Buffer vertex;   // float3*
+  gprt::Texture texture;
+  float2 resolution;
 };
 
 /* Constants that change each frame */
 struct PushConstants {
-  alignas(16) float4x4 view;
-  alignas(16) float4x4 proj;
+  float4x4 view;
+  float4x4 proj;
 };

--- a/samples/s12-swBVH/sharedCode.h
+++ b/samples/s12-swBVH/sharedCode.h
@@ -25,27 +25,27 @@
 
 /* variables available to all programs */
 struct RayGenData {
-  alignas(16) gprt::Buffer frameBuffer;
-  alignas(16) gprt::Buffer accumBuffer;
+  gprt::Buffer frameBuffer;
+  gprt::Buffer accumBuffer;
   LBVHData lbvh;
 };
 
 /* variables for the miss program */
 struct MissProgData {
-  alignas(16) float3 color0;
-  alignas(16) float3 color1;
+  float3 color0;
+  float3 color1;
 };
 
 /* Constants that change each frame */
 struct PushConstants {
-  alignas(4) float iTime;
-  alignas(4) int iFrame;
-  alignas(4) float cuttingPlane;
+  float iTime;
+  int iFrame;
+  float cuttingPlane;
 
   struct {
-    alignas(16) float3 pos;
-    alignas(16) float3 dir_00;
-    alignas(16) float3 dir_du;
-    alignas(16) float3 dir_dv;
+    float3 pos;
+    float3 dir_00;
+    float3 dir_du;
+    float3 dir_dv;
   } camera;
 };


### PR DESCRIPTION
In GPRT, we depend on C/C++ and HLSL structs to align. At the moment, we're using alignas to try to get C++ structs to match their HLSL auto-aligned counterparts, but this gets very messy as we add more and more members to structs. It's also not always straightforward to get C++ structs to actually line up to odd std430 rules, and can be very difficult to debug.

This PR moves us over to a Vulkan feature that causes all structs to follow scalar alignment, matching C/C++ alignment rules. The resulting code in the sharedCode.h files is very simplified. 

All samples so far seem to work on Windows on an NVIDIA card, but could use testing on AMD / Intel ARC, also on Linux.

I'm noticing a validation error with push constant structs, but I suspect this is a bug with the validation layers... 