### PR TITLE
Updates to CI and compilation fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         submodules: recursive
 
     - name: Prepare Vulkan SDK
-      uses: humbletim/install-vulkan-sdk@v1.1.1
+      uses: humbletim/install-vulkan-sdk@v1.2
       with:
         version: 1.3.296.0
         cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         submodules: recursive
 
     - name: Prepare Vulkan SDK
-      uses: humbletim/install-vulkan-sdk@v1.1.1
+      uses: humbletim/install-vulkan-sdk@v1.2
       with:
         version: 1.3.296.0
         cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Prepare Vulkan SDK
       uses: humbletim/install-vulkan-sdk@v1.2
       with:
-        version: 1.3.296.0
+        version: 1.4.309.0
         cache: true
 
     - name: Apt dependencies
@@ -76,7 +76,7 @@ jobs:
     - name: Prepare Vulkan SDK
       uses: humbletim/install-vulkan-sdk@v1.2
       with:
-        version: 1.3.296.0
+        version: 1.4.309.0
         cache: true
 
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -25,7 +25,7 @@ jobs:
       with:
         version: 1.3.296.0
         cache: true
-      
+
     - name: Apt dependencies
       shell: bash
       run: |
@@ -37,7 +37,7 @@ jobs:
                             libglu1-mesa-dev \
                             freeglut3-dev \
                             mesa-common-dev
-                            
+
     - name: Build Shared
       shell: bash
       run: |
@@ -47,9 +47,9 @@ jobs:
         cmake --version
         cmake .. -DGPRT_BUILD_SHARED=ON
         make VERBOSE=1 -j4
-    
-    
-      
+
+
+
     - name: Build Static
       shell: bash
       run: |
@@ -59,26 +59,26 @@ jobs:
         cmake --version
         cmake ..
         make VERBOSE=1 -j4
-    
+
     # Useful for debugging
     # - name: Debug with tmate on failure
     #   if: ${{ failure() }}
     #   uses: mxschmitt/action-tmate@v3
-    
+
   windows:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
-    
+
     - name: Prepare Vulkan SDK
       uses: humbletim/install-vulkan-sdk@v1.1.1
       with:
         version: 1.3.296.0
         cache: true
-    
+
     - name: Build
       shell: bash
       run: |

--- a/gprt/cmake/embed_devicecode.cmake
+++ b/gprt/cmake/embed_devicecode.cmake
@@ -33,7 +33,7 @@ function(embed_devicecode)
 
   unset(EMBED_DEVICECODE_OUTPUTS)
 
-  set(EMBED_DEVICECODE_DEBUG_OPT_FLAG $<$<CONFIG:Debug>:-O0>)  
+  set(EMBED_DEVICECODE_DEBUG_OPT_FLAG $<$<CONFIG:Debug>:-O0>)
   set(EMBED_DEVICECODE_RELEASE_OPT_FLAG $<$<CONFIG:RelWithDebInfo,Release>:-O3>)
 
   set(EMBED_DEVICECODE_DEBUG_DEFINES $<$<CONFIG:Debug>:-D__DEBUG__>)
@@ -43,14 +43,14 @@ function(embed_devicecode)
     COMMAND ${CMAKE_SLANG_COMPILER}
     ${EMBED_DEVICECODE_SOURCES}
     -profile sm_6_7
-    -target spirv 
+    -target spirv
     -emit-spirv-directly
     -fspv-reflect
     -force-glsl-scalar-layout
     -fvk-use-entrypoint-name
     -matrix-layout-row-major
     -ignore-capabilities
-    -zero-initialize # zero-initialize all variables
+    #-zero-initialize # zero-initialize all variables
     -Wno-39001 # for VK_EXT_mutable_descriptor_type, allows overlapping bindings
     -fp-mode fast
     -g3
@@ -77,7 +77,7 @@ function(embed_devicecode)
     VERBATIM
     DEPENDS ${EMBED_DEVICECODE_OUTPUT}
     )
-  
+
   add_library(${EMBED_DEVICECODE_OUTPUT_TARGET} OBJECT)
   target_sources(${EMBED_DEVICECODE_OUTPUT_TARGET} PRIVATE ${EMBED_DEVICECODE_CPP_FILE}) #${EMBED_DEVICECODE_H_FILE} #${EMBED_DEVICECODE_SOURCES}
 endfunction()

--- a/gprt/cmake/embed_devicecode.cmake
+++ b/gprt/cmake/embed_devicecode.cmake
@@ -50,7 +50,6 @@ function(embed_devicecode)
     -fvk-use-entrypoint-name
     -matrix-layout-row-major
     -ignore-capabilities
-    #-zero-initialize # zero-initialize all variables
     -Wno-39001 # for VK_EXT_mutable_descriptor_type, allows overlapping bindings
     -fp-mode fast
     -g3


### PR DESCRIPTION
This contains some updates to the CI checkout actions: version 2 is no longer supported. This required an update to the `install-vulkan-sdk` package as well.

When building locally I got some compilation errors for the logging macros so I adjusted how we check that method by checking the attribute of the static object instead using a static method.

One change I'm not so sure about is the removal of the `-zero-initialization` flag for the `slangc` compiler. That flag wasn't added until sometime last year and it doesn't seem to be available yet in the Linux package for the Vulkan SDK provided by LunarG. We could add it based on the `slangc` version perhaps but the version doesn't seem to be standard (`lunarg-ubuntu-noble-package`). Anyway, @natevm if you have some alternative to removing that flag let me know and I'll implement it as needed.