### PR TITLE
Added an option to include additional directories in embed_devicecode

### DIFF
--- a/gprt/cmake/embed_devicecode.cmake
+++ b/gprt/cmake/embed_devicecode.cmake
@@ -28,7 +28,7 @@ function(embed_devicecode)
   # processes arguments given to a function, and defines a set of variables
   #   which hold the values of the respective options
   set(oneArgs OUTPUT_TARGET)
-  set(multiArgs SPIRV_LINK_LIBRARIES SOURCES HEADERS)
+  set(multiArgs SPIRV_LINK_LIBRARIES SOURCES HEADERS INCLUDE_DIRS)
   cmake_parse_arguments(EMBED_DEVICECODE "" "${oneArgs}" "${multiArgs}" ${ARGN})
 
   unset(EMBED_DEVICECODE_OUTPUTS)
@@ -37,6 +37,12 @@ function(embed_devicecode)
   set(EMBED_DEVICECODE_RELEASE_OPT_FLAG $<$<CONFIG:RelWithDebInfo,Release>:-O3>)
 
   set(EMBED_DEVICECODE_DEBUG_DEFINES $<$<CONFIG:Debug>:-D__DEBUG__>)
+
+  # build a list of all additional (external to GPRT) included directories
+  set(EMBED_DEVICECODE_INCLUDES)
+  foreach(dir ${EMBED_DEVICECODE_INCLUDE_DIRS})
+    list(APPEND EMBED_DEVICECODE_INCLUDES "-I" "${dir}")
+  endforeach()
 
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${EMBED_DEVICECODE_OUTPUT_TARGET}.spv
@@ -58,6 +64,7 @@ function(embed_devicecode)
     ${EMBED_DEVICECODE_RELEASE_OPT_FLAG}
     -I ${GPRT_INCLUDE_DIR}
     ${EMBED_DEVICECODE_DEBUG_DEFINES}
+    ${EMBED_DEVICECODE_INCLUDES} 
     -o ${CMAKE_CURRENT_BINARY_DIR}/${EMBED_DEVICECODE_OUTPUT_TARGET}.spv
     DEPENDS ${EMBED_DEVICECODE_SOURCES} ${EMBED_DEVICECODE_HEADERS} ${GPRT_INCLUDE_DIR}/gprt.slang ${GPRT_INCLUDE_DIR}/gprt.h
   )


### PR DESCRIPTION
Very minor change here but I wanted to make including headers from another library a little more convenient when compiling the slang code. 

A new `INCLUDE_DIRS` argument has been added to the `embed_devicecode()` cmake function, allowing users to specify additional include directories that will be passed to slangc via -I flags during shader compilation. It just makes it slightly more convenient for me to include additional headers in my project. I can use project relative includes instead of filesystem relative paths:
```
#include "../geometry/dp_math.h" ---> OLD
#include "xdg/geometry/dp_math.h" ---> NEW
```

Example usage of the `INCLUDE_DIRS` argument:
```
    embed_devicecode(
    OUTPUT_TARGET
    ${device_code}
    HEADERS
    ${CMAKE_CURRENT_SOURCE_DIR}/include/xdg/gprt/shared_structs.h
    SOURCES
    ${CMAKE_CURRENT_SOURCE_DIR}/src/gprt/${device_code}.slang
    INCLUDE_DIRS
    ${CMAKE_CURRENT_SOURCE_DIR}/include
  )
  ```