### PR TITLE
Update to respect parent scope for BUILD_SHARED_LIBS cmake variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,16 +55,17 @@ endif()
 # Configuration Options
 # ------------------------------------------------------------------
 option(GPRT_BUILD_SHARED "Build GPRT as a shared library? (otherwise static)" OFF)
-set(BUILD_SHARED_LIBS ${GPRT_BUILD_SHARED}) # use 'GPRT_' naming convention
 option(GPRT_USE_INCLUDED_GLFW "Build GPRT including the submoduled GLFW? (otherwise, system GLFW will be found)" ON)  
 
 # ------------------------------------------------------------------
 # External configuration variables
 # ------------------------------------------------------------------
 
-# provide these varaibles at both a local and parent scope
+# provide these variables at both a local and parent scope
 if (GPRT_IS_SUBPROJECT)
   set(GPRT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gprt PARENT_SCOPE)
+else()
+  set(BUILD_SHARED_LIBS ${GPRT_BUILD_SHARED})
 endif()
 set(GPRT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gprt)
 


### PR DESCRIPTION
This PR enforces that CMake should respect the parent scope for the CMake variable `BUILD_SHARED_LIBS` if GPRT is included as a subproject but otherwise can default to the same behaviour it had before if the parent project does not provide a value for this.

Before these changes the line `set(BUILD_SHARED_LIBS ${GPRT_BUILD_SHARED})` would always set `BUILD_SHARED_LIBS` to match `GPRT_BUILD_SHARED` no matter what the parent project was trying to do. So for example, if you wanted to build GPRT as a shared library but keep its dependency libraries static it would be impossible to do so. 