### PR TITLE
Ensure GPRT respects GPRT_BUILD_SHARED 

### DIFF
--- a/gprt/CMakeLists.txt
+++ b/gprt/CMakeLists.txt
@@ -22,9 +22,11 @@
 
 add_subdirectory(math)
 
-add_library(gprt)
 if (GPRT_BUILD_SHARED)
+  add_library(gprt SHARED)
   set_property(TARGET gprt PROPERTY POSITION_INDEPENDENT_CODE ON)
+else()
+  add_library(gprt STATIC)
 endif()
 include(cmake/embed_devicecode.cmake)
 


### PR DESCRIPTION
The CMake option `GPRT_BUILD_SHARED` seems to imply that when set to `ON` GPRT should be built as a shared library and otherwise a static library. But as far as I can tell, irrespective of the value of this CMake option GPRT always builds as a static library as the `gprt\CMakeLists.txt` contains an untyped call to `add_library(gprt)`. 

This PR makes the call explicitly scoped depending on the value of this option. 

I am unsure if the original behaviour was intended or if this is something that was missed prior? 